### PR TITLE
Catch turtle and turtle name fix

### DIFF
--- a/Altis_Life.Altis/core/actions/fn_catchTurtle.sqf
+++ b/Altis_Life.Altis/core/actions/fn_catchTurtle.sqf
@@ -10,7 +10,7 @@ _obj = cursorTarget;
 if(isNull _obj) exitWith {}; //Not valid
 if(alive _obj) exitWith {}; //It's alive, don't take it charlie!
 
-if(([true,"turtle",1] call life_fnc_handleInv)) then {
+if(([true,"turtle_raw",1] call life_fnc_handleInv)) then {
 	deleteVehicle _obj;
 	titleText[localize "STR_NOTF_CaughtTurtle","PLAIN"];
 };

--- a/Altis_Life.Altis/stringtable.xml
+++ b/Altis_Life.Altis/stringtable.xml
@@ -3543,7 +3543,7 @@
       <Portuguese>Tubarão Gato Frito</Portuguese>
       <Polish>Grilowany Rekin</Polish>
     </Key>
-    <Key ID="STR_Item_Turtle">
+    <Key ID="STR_Item_TurtleRaw">
       <Original>Turtle Meat</Original>
       <German>Schildkröten Fleisch</German>
       <French>Viande de Tortue</French>


### PR DESCRIPTION
Caught turtles will now be added to the player's virtual inventory and their name will correctly display. 