### PR TITLE
Quadbike money exploit

### DIFF
--- a/Altis_Life.Altis/Config_Vehicles.hpp
+++ b/Altis_Life.Altis/Config_Vehicles.hpp
@@ -516,7 +516,7 @@ class LifeCfgVehicles {
         storageFee[] = { 1000, 0, 0, 0 };
         garageSell[] = { 950, 0, 0, 0 };
         insurance = 2500;
-        chopShop = 5000;
+        chopShop = 1250;
         textures[] = {
             { "Brown", "cop", {
                 "\A3\Soft_F\Quadbike_01\Data\Quadbike_01_co.paa"


### PR DESCRIPTION
Purchase quad bike and sell at a chop shop for a profit. 
Would suggest that chopshop prices are defined by 50% of what the car is worth in the config.
I don't think insurance works either.