### PR TITLE
Update ATMRobbed

### DIFF
--- a/Altis_Life.Altis/core/shops/fn_atmMenu.sqf
+++ b/Altis_Life.Altis/core/shops/fn_atmMenu.sqf
@@ -9,7 +9,7 @@
 private["_units","_type"];
 
 if(!life_use_atm) exitWith {
-	hint localize "STR_Shop_ATMRobbed";
+	hint format [localize "STR_Shop_ATMRobbed",(LIFE_SETTINGS(getNumber,"noatm_timer"))]
 };
 
 if(!dialog) then {

--- a/Altis_Life.Altis/stringtable.xml
+++ b/Altis_Life.Altis/stringtable.xml
@@ -5003,7 +5003,7 @@
   </Package>
   <Package name="Shop_Strings">
     <Key ID="STR_Shop_ATMRobbed">
-      <Original>Because you robbed the bank you can't use the ATM for 5 minutes.</Original>
+      <Original>Because you robbed the bank you can't use the ATM for %1 minutes.</Original>
       <German>Da du die Bank ausgeraubt hast, kannst du für 5 Minuten keine Bankomaten benutzen.</German>
       <French>Vous avez pillé la banque, vous ne pouvez pas utiliser le guichet automatique pendant 5 minutes.</French>
       <Italian>Avendo appena rapinato la banca non puoi utilizzare il Bancomat per 5 minuti.</Italian>


### PR DESCRIPTION
The number of minutes stated where the federal reserve robber cannot use an ATM (STR_Shop_ATMRobbed) will reflect what is specified in Config_Master.hpp → noatm_timer