### PR TITLE
Warning Spam Fix numba 2

### DIFF
--- a/Altis_Life.Altis/core/functions/fn_playerTags.sqf
+++ b/Altis_Life.Altis/core/functions/fn_playerTags.sqf
@@ -9,6 +9,7 @@
 private["_ui","_units"];
 #define iconID 78000
 #define scale 0.8
+if(!(!isDedicated && hasInterface)) exitWith {};
 
 if(visibleMap OR {!alive player} OR {dialog}) exitWith {
 	500 cutText["","PLAIN"];


### PR DESCRIPTION
Fixes the WARNING: Function 'name' that spams to the RPT. Tested to verify you can still see NPC names/player tags on users. Not sure if this line would be better to add on the **core\init.sqf** to the stacked event handler? @danielstuart14 maybe you can find the more "performance optimized" solution.

Reason for this issue was because Bohemia made dead units go completely null...

@danielstuart14, you could potentially revert https://github.com/ArmaLife/Altis/commit/7ff46c2f3a5bf4fefdd904fb7deab6be32502983 if you want. It seems to have **completely** fixed the bodies staying around or names showing on dead bodies and stuff like that though..
