### PR TITLE
Fix key give

### DIFF
--- a/Altis_Life.Altis/core/pmenu/fn_keyGive.sqf
+++ b/Altis_Life.Altis/core/pmenu/fn_keyGive.sqf
@@ -2,7 +2,7 @@
 /*
 	File: fn_keyGive.sqf
 	Author: Bryan "Tonic" Boardwine
-	
+
 	Description:
 	Gives a copy of the key for the selected vehicle to the selected player.
 	Player must be within range.
@@ -14,14 +14,17 @@ _dialog = findDisplay 2700;
 _list = _dialog displayCtrl 2701;
 _plist = _dialog displayCtrl 2702;
 
+if((lbCurSel 2701) == -1) exitWith {hint "You didn't select a vehicle.";};
 _sel = lbCurSel _list;
 _vehicle = _list lbData _sel;
 _vehicle = life_vehicles select parseNumber(_vehicle);
 
+if((lbCurSel 2702) == -1) exitWith {hint "You didn't select a player.";};
 _sel = lbCurSel _plist;
 _unit = _plist lbData _sel;
 _unit = call compile format["%1", _unit];
-if(isNull _unit OR isNil "_unit") exitWith {}; 
+if(isNull _unit OR isNil "_unit") exitWith {};
+if(_unit == player) exitWith {};
 
 _uid = getPlayerUID _unit;
 _owners = _vehicle GVAR "vehicle_info_owners";


### PR DESCRIPTION
Fix problem when give key if you don't select a vehicle or a player


Fix for issue : Error in expression - fn_keyGive.sqf #131