### PR TITLE
Fix Revive Gear

### DIFF
--- a/Altis_Life.Altis/core/configuration.sqf
+++ b/Altis_Life.Altis/core/configuration.sqf
@@ -37,6 +37,7 @@ life_god = false;
 life_frozen = false;
 life_markers = false;
 life_fed_break = 0;
+life_save_gear = [];
 
 //Uniform price (0),Hat Price (1),Glasses Price (2),Vest Price (3),Backpack Price (4)
 life_clothing_purchase = [-1,-1,-1,-1,-1];

--- a/Altis_Life.Altis/core/medical/fn_onPlayerKilled.sqf
+++ b/Altis_Life.Altis/core/medical/fn_onPlayerKilled.sqf
@@ -2,7 +2,7 @@
 /*
 	File: fn_onPlayerKilled.sqf
 	Author: Bryan "Tonic" Boardwine
-	
+
 	Description:
 	When the player dies collect various information about that player
 	and pull up the death dialog / camera functionality.
@@ -41,10 +41,10 @@ _unit spawn {
 	disableSerialization;
 	_RespawnBtn = ((findDisplay 7300) displayCtrl 7302);
 	_Timer = ((findDisplay 7300) displayCtrl 7301);
-	
+
 	_maxTime = time + (life_respawn_timer * 60);
 	_RespawnBtn ctrlEnable false;
-	waitUntil {_Timer ctrlSetText format[localize "STR_Medic_Respawn",[(_maxTime - time),"MM:SS.MS"] call BIS_fnc_secondsToString]; 
+	waitUntil {_Timer ctrlSetText format[localize "STR_Medic_Respawn",[(_maxTime - time),"MM:SS.MS"] call BIS_fnc_secondsToString];
 	round(_maxTime - time) <= 0 OR isNull _this};
 	_RespawnBtn ctrlEnable true;
 	_Timer ctrlSetText localize "STR_Medic_Respawn_2";
@@ -69,12 +69,14 @@ if(!isNull _killer && {_killer != _unit} && {side _killer != west} && {alive _ki
 		};
 	} else {
 		[getPlayerUID _killer,_killer GVAR ["realname",name _killer],"187"] remoteExecCall ["life_fnc_wantedAdd",RSERV];
-		
+
 		if(!local _killer) then {
 			[3] remoteExecCall ["life_fnc_removeLicenses",_killer];
 		};
 	};
 };
+
+life_save_gear = [player] call life_fnc_fetchDeadGear;
 
 //Killed by cop stuff...
 if(side _killer == west && playerSide != west) then {

--- a/Altis_Life.Altis/core/medical/fn_revived.sqf
+++ b/Altis_Life.Altis/core/medical/fn_revived.sqf
@@ -10,8 +10,7 @@ private["_medic","_dir","_reviveCost"];
 _medic = param [0,"Unknown Medic",[""]];
 _reviveCost = LIFE_SETTINGS(getNumber,"revive_fee");
 
-_oldGear = [life_corpse] call life_fnc_fetchDeadGear;
-[_oldGear] spawn life_fnc_loadDeadGear;
+[life_save_gear] spawn life_fnc_loadDeadGear;
 life_corpse SVAR ["realname",nil,true]; //Should correct the double name sinking into the ground.
 [life_corpse] remoteExecCall ["life_fnc_corpse",RANY];
 


### PR DESCRIPTION
So currently if you get revived you don't keep your primary since its fetching dead gear when your primary is already on the ground basically and no longer considered to be your primary and then it gets deleted before making it to the fetch. 

This method will now fetch your gear successfully and then when you get revived you keep your primary weapon.