### PR TITLE
Updated police vehicles, misc

### DIFF
--- a/Altis_Life.Altis/Config_Master.hpp
+++ b/Altis_Life.Altis/Config_Master.hpp
@@ -70,7 +70,7 @@ class Life_Settings {
     civ_skins = false; //Enable or disable civilian skins. Before enabling, you must add all the SEVEN files to textures folder. (It must be named as: civilian_uniform_1.jpg, civilian_uniform_2.jpg...civilian_uniform_6.jpg, civilian_uniform_7.jpg)
 
     /* Car-shop Settings */
-    vehicleShop_rentalOnly[] = { "B_MRAP_01_hmg_F", "B_G_Offroad_01_armed_F" };
+    vehicleShop_rentalOnly[] = { "B_MRAP_01_hmg_F", "B_G_Offroad_01_armed_F", "B_Boat_Armed_01_minigun_F" };
 
     /* Job-related stuff */
     delivery_points[] = { "dp_1", "dp_2", "dp_3", "dp_4", "dp_5", "dp_6", "dp_7", "dp_8", "dp_9", "dp_10", "dp_11", "dp_12", "dp_13", "dp_14", "dp_15", "dp_15", "dp_16", "dp_17", "dp_18", "dp_19", "dp_20", "dp_21", "dp_22", "dp_23", "dp_24", "dp_25" };

--- a/Altis_Life.Altis/Config_Vehicles.hpp
+++ b/Altis_Life.Altis/Config_Vehicles.hpp
@@ -73,7 +73,7 @@ class CarShops {
         side = "civ";
         vehicles[] = {
             { "B_Quadbike_01_F", 2500, { "" }, { "", "", -1 } },
-            { "B_G_Offroad_01_F", 15000, { "" }, { "", "", -1 } },
+            { "B_G_Offroad_01_F", 12500, { "" }, { "", "", -1 } },
             { "O_MRAP_02_F", 150000, { "" }, { "", "", -1 } },
             { "B_Heli_Light_01_F", 325000, { "" }, { "", "", -1 } },
             { "B_G_Offroad_01_armed_F", 750000, { "rebel" }, { "", "", -1 } }
@@ -85,7 +85,9 @@ class CarShops {
         vehicles[] = {
             { "C_Offroad_01_F", 5000, { "" }, { "", "", -1 } },
             { "C_SUV_01_F", 20000, { "" }, { "", "", -1 } },
-            { "B_MRAP_01_F", 30000, { "" }, { "life_coplevel", "SCALAR", 3 } }
+            { "C_Hatchback_01_sport_F", 30000, { "" }, { "life_coplevel", "SCALAR", 1 } },
+            { "B_MRAP_01_F", 30000, { "" }, { "life_coplevel", "SCALAR", 2 } },
+            { "B_MRAP_01_hmg_F", 750000, { "" }, { "life_coplevel", "SCALAR", 3 } }
         };
     };
 
@@ -101,8 +103,7 @@ class CarShops {
         side = "cop";
         vehicles[] = {
             { "B_Heli_Light_01_F", 75000, { "cAir" }, { "", "", -1 } },
-            { "B_Heli_Transport_01_F", 200000, { "cAir" }, { "life_coplevel", "SCALAR", 3 } },
-            { "B_MRAP_01_hmg_F", 750000, { "" }, { "life_coplevel", "SCALAR", 3 } }
+            { "B_Heli_Transport_01_F", 200000, { "cAir" }, { "life_coplevel", "SCALAR", 3 } }
         };
     };
 
@@ -111,7 +112,7 @@ class CarShops {
         vehicles[] = {
             { "B_Boat_Transport_01_F", 3000, { "cg" }, { "", "", -1 } },
             { "C_Boat_Civil_01_police_F", 20000, { "cg" }, { "", "", -1 } },
-            { "B_Boat_Armed_01_minigun_F", 75000, { "cg" }, { "", "", -1 } },
+            { "B_Boat_Armed_01_minigun_F", 75000, { "cg" }, { "life_coplevel", "SCALAR", 3 } },
             { "B_SDV_01_F", 100000, { "cg" }, { "", "", -1 } }
         };
     };
@@ -164,7 +165,7 @@ class LifeCfgVehicles {
         storageFee[] = { 0, 0, 1500, 0 };
         garageSell[] = { 0, 0, 5000, 0 };
         insurance = 2500;
-        chopShop = 3000;
+        chopShop = 12500;
         textures[] = {};
     };
 
@@ -173,7 +174,7 @@ class LifeCfgVehicles {
         storageFee[] = { 0, 0, 3000, 0 };
         garageSell[] = { 0, 0, 10000, 0 };
         insurance = 2500;
-        chopShop = 7500;
+        chopShop = 22500;
         textures[] = {};
     };
 
@@ -182,7 +183,7 @@ class LifeCfgVehicles {
         storageFee[] = { 0, 0, 6500, 0 };
         garageSell[] = { 0, 0, 25000, 0 };
         insurance = 2500;
-        chopShop = 12500;
+        chopShop = 30000;
         textures[] = {};
     };
 
@@ -191,7 +192,7 @@ class LifeCfgVehicles {
         storageFee[] = { 400, 300, 0, 0 };
         garageSell[] = { 950, 350, 0, 0 };
         insurance = 2500;
-        chopShop = 5000;
+        chopShop = 2500;
         textures[] = { };
     };
 
@@ -209,8 +210,14 @@ class LifeCfgVehicles {
         storageFee[] = { 1000, 1000, 1000, 1000 };
         garageSell[] = { 0, 0, 0, 0 };
         insurance = 2500;
-        chopShop = 1200;
-        textures[] = {};
+        chopShop = 100000;
+        textures[] = {
+            { "Black", "cop", {
+                "#(argb,8,8,3)color(0.05,0.05,0.05,1)",
+                "#(argb,8,8,3)color(0.05,0.05,0.05,1)",
+                "#(argb,8,8,3)color(0.05,0.05,0.05,1)"
+            } }
+        };
     };
 
     class O_Boat_Armed_01_hmg_F {
@@ -263,7 +270,7 @@ class LifeCfgVehicles {
         storageFee[] = { 1000, 0, 0, 0 };
         garageSell[] = { 3500, 0, 0, 0 };
         insurance = 2500;
-        chopShop = 5000;
+        chopShop = 100000;
         textures[] = { };
     };
 
@@ -272,7 +279,7 @@ class LifeCfgVehicles {
         storageFee[] = { 95000, 0, 0, 0 };
         garageSell[] = { 185000, 0, 0, 0 };
         insurance = 25000;
-        chopShop = 125000;
+        chopShop = 225000;
         textures[] = { };
     };
 
@@ -308,7 +315,7 @@ class LifeCfgVehicles {
         storageFee[] = { 1000, 0, 0, 0 };
         garageSell[] = { 3500, 0, 0, 0 };
         insurance = 2500;
-        chopShop = 5000;
+        chopShop = 6250;
         textures[] = { };
     };
 
@@ -317,7 +324,7 @@ class LifeCfgVehicles {
         storageFee[] = { 1500, 0, 0, 0 };
         garageSell[] = { 4000, 0, 0, 0 };
         insurance = 2500;
-        chopShop = 5000;
+        chopShop = 100000;
         textures[] = { };
     };
 
@@ -335,7 +342,7 @@ class LifeCfgVehicles {
         storageFee[] = { 4500, 2500, 0, 0 };
         garageSell[] = { 6800, 3500, 0, 0 };
         insurance = 2500;
-        chopShop = 5000;
+        chopShop = 11000;
         textures[] = { };
     };
 
@@ -362,7 +369,7 @@ class LifeCfgVehicles {
         storageFee[] = { 35000, 0, 0, 0 };
         garageSell[] = { 150000, 0, 0, 0 };
         insurance = 2500;
-        chopShop = 5000;
+        chopShop = 175000;
         textures[] = { };
     };
 
@@ -371,7 +378,7 @@ class LifeCfgVehicles {
         storageFee[] = { 25650, 0, 0, 0 };
         garageSell[] = { 135000, 0, 0, 0 };
         insurance = 2500;
-        chopShop = 5000;
+        chopShop = 127500;
         textures[] = { };
     };
 
@@ -380,7 +387,7 @@ class LifeCfgVehicles {
         storageFee[] = { 45000, 0, 0, 0 };
         garageSell[] = { 65000, 0, 0, 0 };
         insurance = 2500;
-        chopShop = 5000;
+        chopShop = 75000;
         textures[] = { };
     };
 
@@ -398,7 +405,7 @@ class LifeCfgVehicles {
         storageFee[] = { 1000, 500, 650, 1000 };
         garageSell[] = { 6500, 2500, 0, 0 };
         insurance = 2500;
-        chopShop = 2500;
+        chopShop = 6250;
         textures[] = {
             { "Red", "civ", {
                 "\A3\soft_F\Offroad_01\Data\offroad_01_ext_co.paa",
@@ -427,9 +434,6 @@ class LifeCfgVehicles {
             { "Taxi", "civ", {
                 "#(argb,8,8,3)color(0.6,0.3,0.01,1)"
             } },
-            { "Fed", "cop", {
-                "#(ai,64,64,1)Fresnel(0.3,3)"
-            } },
             { "Police", "cop", {
                 "#(ai,64,64,1)Fresnel(1.3,7)"
             } }
@@ -441,7 +445,7 @@ class LifeCfgVehicles {
         storageFee[] = { 1500, 0, 0, 0 };
         garageSell[] = { 3500, 0, 0, 0 };
         inusrance = 1650;
-        chopShop = 3500;
+        chopShop = 7500;
         textures[] = {};
     };
 
@@ -450,7 +454,7 @@ class LifeCfgVehicles {
         storageFee[] = { 1500, 0, 0, 0 };
         garageSell[] = { 3500, 0, 0, 0 };
         inusrance = 1650;
-        chopShop = 3500;
+        chopShop = 7500;
         textures[] = {};
     };
 
@@ -459,7 +463,7 @@ class LifeCfgVehicles {
         storageFee[] = { 1500, 0, 0, 0 };
         garageSell[] = { 3500, 0, 0, 0 };
         inusrance = 1650;
-        chopShop = 3500;
+        chopShop = 7500;
         textures[] = {};
     };
 
@@ -468,7 +472,7 @@ class LifeCfgVehicles {
         storageFee[] = { 1500, 0, 0, 0 };
         garageSell[] = { 3500, 0, 0, 0 };
         inusrance = 1650;
-        chopShop = 3500;
+        chopShop = 7500;
         textures[] = {};
     };
 
@@ -477,7 +481,7 @@ class LifeCfgVehicles {
         storageFee[] = { 2500, 1000, 0, 0 };
         garageSell[] = { 15000, 7500, 0, 0 };
         insurance = 5500;
-        chopShop = 4500;
+        chopShop = 15000;
         textures[] = {
             { "Red", "civ", {
                 "\a3\soft_f_gamma\Hatchback_01\data\hatchback_01_ext_sport01_co.paa"
@@ -545,7 +549,7 @@ class LifeCfgVehicles {
         storageFee[] = { 14500, 0, 0, 0 };
         garageSell[] = { 62000, 0, 0, 0 };
         insurance = 6500;
-        chopShop = 20000;
+        chopShop = 50000;
         textures[] = {
             { "Orange", "civ", {
                 "\A3\Soft_F_Beta\Truck_02\data\truck_02_kab_co.paa",
@@ -562,7 +566,7 @@ class LifeCfgVehicles {
         storageFee[] = { 12000, 0, 0, 0 };
         garageSell[] = { 49800, 3500, 0, 0 };
         insurance = 6500;
-        chopShop = 20000;
+        chopShop = 37500;
         textures[] = {
             { "Orange", "civ", {
                 "\A3\Soft_F_Beta\Truck_02\data\truck_02_kab_co.paa",
@@ -579,7 +583,7 @@ class LifeCfgVehicles {
         storageFee[] = { 25000, 0, 0, 0 };
         garageSell[] = { 65000, 0, 0, 0 };
         insurance = 2500;
-        chopShop = 5000;
+        chopShop = 125000;
         textures[] = {};
     };
 
@@ -588,7 +592,7 @@ class LifeCfgVehicles {
         storageFee[] = { 1000, 0, 0, 0 };
         garageSell[] = { 4500, 3500, 0, 0 };
         insurance = 2500;
-        chopShop = 5000;
+        chopShop = 4750;
         textures[] = {
             { "Beige", "civ", {
                 "\a3\soft_f_gamma\Hatchback_01\data\hatchback_01_ext_base01_co.paa"
@@ -622,13 +626,10 @@ class LifeCfgVehicles {
         storageFee[] = { 1000, 0, 0, 0 };
         garageSell[] = { 15000, 7500, 0, 0 };
         insurance = 2500;
-        chopShop = 5000;
+        chopShop = 15000;
         textures[] = {
             { "Dark Red", "civ", {
                 "\a3\soft_f_gamma\SUV_01\Data\suv_01_ext_co.paa"
-            } },
-            { "Black", "cop", {
-                "\a3\soft_f_gamma\SUV_01\Data\suv_01_ext_02_co.paa"
             } },
             { "Silver", "civ", {
                 "\a3\soft_f_gamma\SUV_01\Data\suv_01_ext_03_co.paa"
@@ -636,9 +637,9 @@ class LifeCfgVehicles {
             { "Orange", "civ", {
                 "\a3\soft_f_gamma\SUV_01\Data\suv_01_ext_04_co.paa"
             } },
-            { "Cop", "cop", {
-                "#(ai,64,64,1)Fresnel(1.3,7)"
-            } }
+            { "Police", "cop", {
+                "\a3\soft_f_gamma\SUV_01\Data\suv_01_ext_02_co.paa"
+            } },
         };
     };
 
@@ -647,7 +648,7 @@ class LifeCfgVehicles {
         storageFee[] = { 1000, 0, 0, 0 };
         garageSell[] = { 25000, 0, 0, 0 };
         insurance = 2500;
-        chopShop = 5000;
+        chopShop = 22500;
         textures[] = {
             { "White", "civ", {
                 "\a3\soft_f_gamma\Van_01\Data\van_01_ext_co.paa"
@@ -663,7 +664,7 @@ class LifeCfgVehicles {
         storageFee[] = { 1000, 0, 0, 0 };
         garageSell[] = { 35000, 0, 0, 0 };
         insurance = 2500;
-        chopShop = 5000;
+        chopShop = 30000;
         textures[] = {
             { "White", "civ", {
                 "\a3\soft_f_gamma\Van_01\Data\van_01_ext_co.paa"
@@ -679,12 +680,10 @@ class LifeCfgVehicles {
         storageFee[] = { 0, 7500, 0, 0 };
         garageSell[] = { 0, 10000, 0, 0 };
         insurance = 2500;
-        chopShop = 5000;
+        chopShop = 15000;
         textures[] = {
-            { "Regular", "cop", {
-                "\A3\Soft_F\MRAP_01\Data\mrap_01_base_co.paa"
-            } },
             { "Black", "cop", {
+                "#(argb,8,8,3)color(0.05,0.05,0.05,1)",
                 "#(argb,8,8,3)color(0.05,0.05,0.05,1)"
             } }
         };
@@ -695,22 +694,19 @@ class LifeCfgVehicles {
         storageFee[] = { 45000, 19500, 0, 0 };
         garageSell[] = { 57000, 35000, 0, 0 };
         insurance = 2500;
-        chopShop = 5000;
+        chopShop = 125000;
         textures[] = {
-            { "Sheriff", "cop", {
-                "\a3\air_f\Heli_Light_01\Data\Skins\heli_light_01_ext_sheriff_co.paa"
-            } },
-            { "Black", "cop", {
+            { "Police", "cop", {
                 "\a3\air_f\Heli_Light_01\Data\heli_light_01_ext_ion_co.paa"
+            } },
+            { "Sheriff", "civ", {
+                "\a3\air_f\Heli_Light_01\Data\Skins\heli_light_01_ext_sheriff_co.paa"
             } },
             { "Civ Blue", "civ", {
                 "\a3\air_f\Heli_Light_01\Data\heli_light_01_ext_blue_co.paa"
             } },
             { "Civ Red", "civ", {
                 "\a3\air_f\Heli_Light_01\Data\heli_light_01_ext_co.paa"
-            } },
-            { "Digi Green", "civ", {
-                "\a3\air_f\Heli_Light_01\Data\heli_light_01_ext_indp_co.paa"
             } },
             { "Blueline", "civ", {
                 "\a3\air_f\Heli_Light_01\Data\Skins\heli_light_01_ext_blueline_co.paa"
@@ -739,6 +735,9 @@ class LifeCfgVehicles {
             { "Rebel Digital", "reb", {
                 "\a3\air_f\Heli_Light_01\Data\Skins\heli_light_01_ext_digital_co.paa"
             } },
+            { "Digi Green", "reb", {
+                "\a3\air_f\Heli_Light_01\Data\heli_light_01_ext_indp_co.paa"
+            } },
             { "EMS White", "med", {
                 "#(argb,8,8,3)color(1,1,1,0.8)"
             } }
@@ -750,7 +749,7 @@ class LifeCfgVehicles {
         storageFee[] = { 55000, 0, 22000, 0 };
         garageSell[] = { 72500, 0, 35000, 0 };
         insurance = 2500;
-        chopShop = 5000;
+        chopShop = 375000;
         textures[] = {
             { "Black", "cop", {
                 "\a3\air_f\Heli_Light_02\Data\heli_light_02_ext_co.paa"
@@ -788,5 +787,14 @@ class LifeCfgVehicles {
                 "\a3\air_f_beta\Heli_Transport_02\Data\Skins\heli_transport_02_3_dahoman_co.paa"
             } }
         };
+    };
+
+    class B_SDV_01_F {
+        vItemSpace = 50;
+        storageFee[] = { 37500, 10000, 0, 0 };
+        garageSell[] = { 75000, 50000, 0, 0 };
+        insurance = 2500;
+        chopShop = 75000;
+        textures[] = {};
     };
 };

--- a/Altis_Life.Altis/core/cop/fn_copLights.sqf
+++ b/Altis_Life.Altis/core/cop/fn_copLights.sqf
@@ -35,6 +35,21 @@ switch (typeOf _vehicle) do
 	{
 		_lightleft lightAttachObject [_vehicle, [-0.37,-1.2,0.42]];
 	};
+	
+	case "C_Hatchback_01_sport_F":
+	{
+		_lightleft lightAttachObject [_vehicle, [-0.35,-0.2,0.25]];
+	};
+	
+	case "B_Heli_Light_01_F":
+	{
+		_lightleft lightAttachObject [_vehicle,[-0.37, 0.0, -0.80]];
+	};
+	
+	case "B_Heli_Transport_01_F":
+	{			
+		_lightleft lightAttachObject [_vehicle, [-0.5, 0.0, 0.81]];
+ 	};
 };
 
 _lightleft setLightAttenuation [0.181, 0, 1000, 130]; 
@@ -65,6 +80,21 @@ switch (typeOf _vehicle) do
 	{
 		_lightright lightAttachObject [_vehicle, [0.37,-1.2,0.42]];
 	};
+	
+	case "C_Hatchback_01_sport_F":
+	{
+		_lightright lightAttachObject [_vehicle, [0.35,-0.2,0.25]];
+	};
+	
+	case "B_Heli_Light_01_F":
+	{
+		_lightright lightAttachObject [_vehicle,[0.37, 0.0, -0.80]];
+	};
+	
+	case "B_Heli_Transport_01_F":
+	{			
+		_lightright lightAttachObject [_vehicle, [0.5, 0.0, 0.81]];
+ 	};
 };
   
 _lightright setLightAttenuation [0.181, 0, 1000, 130]; 

--- a/Altis_Life.Altis/core/cop/fn_sirenLights.sqf
+++ b/Altis_Life.Altis/core/cop/fn_sirenLights.sqf
@@ -10,7 +10,7 @@
 private["_vehicle"];
 _vehicle = param [0,ObjNull,[ObjNull]];
 if(isNull _vehicle) exitWith {}; //Bad entry!
-if(!(typeOf _vehicle in ["C_Offroad_01_F","B_MRAP_01_F","C_SUV_01_F"])) exitWith {}; //Last chance check to prevent something from defying humanity and creating a monster.
+if(!(typeOf _vehicle in ["C_Offroad_01_F","B_MRAP_01_F","C_SUV_01_F","C_Hatchback_01_sport_F","B_Heli_Light_01_F","B_Heli_Transport_01_F"])) exitWith {}; //Last chance check to prevent something from defying humanity and creating a monster.
 
 _trueorfalse = _vehicle GVAR ["lights",FALSE];
 

--- a/Altis_Life.Altis/core/functions/fn_keyHandler.sqf
+++ b/Altis_Life.Altis/core/functions/fn_keyHandler.sqf
@@ -161,7 +161,7 @@ switch (_code) do {
 	case 38: {
 		//If cop run checks for turning lights on.
 		if(_shift && playerSide in [west,independent]) then {
-			if(vehicle player != player && (typeOf vehicle player) in ["C_Offroad_01_F","B_MRAP_01_F","C_SUV_01_F"]) then {
+			if(vehicle player != player && (typeOf vehicle player) in ["C_Offroad_01_F","B_MRAP_01_F","C_SUV_01_F","C_Hatchback_01_sport_F","B_Heli_Light_01_F","B_Heli_Transport_01_F"]) then {
 				if(!isNil {vehicle player GVAR "lights"}) then {
 					if(playerSide == west) then {
 						[vehicle player] call life_fnc_sirenLights;

--- a/life_server/Functions/Systems/fn_spawnVehicle.sqf
+++ b/life_server/Functions/Systems/fn_spawnVehicle.sqf
@@ -127,7 +127,7 @@ if(EQUAL(SEL(_vInfo,1),"civ") && EQUAL(SEL(_vInfo,2),"B_Heli_Light_01_F") && !(E
 	[_vehicle,"civ_littlebird",true] remoteExecCall ["life_fnc_vehicleAnimate",_unit];
 };
 
-if(EQUAL(SEL(_vInfo,1),"cop") && (SEL(_vInfo,2)) in ["C_Offroad_01_F","B_MRAP_01_F","C_SUV_01_F"]) then {
+if(EQUAL(SEL(_vInfo,1),"cop") && (SEL(_vInfo,2)) in ["C_Offroad_01_F","B_MRAP_01_F","C_SUV_01_F","C_Hatchback_01_sport_F","B_Heli_Light_01_F","B_Heli_Transport_01_F"]) then {
 	[_vehicle,"cop_offroad",true] remoteExecCall ["life_fnc_vehicleAnimate",_unit];
 };
 


### PR DESCRIPTION
##### Config_Master:
- Speedboat Minigun now rentable-only. 

##### Config_Vehicles:
- Added Hatchback (Sport) for police. 
- Moved Hunter HMG to cop_car from cop_air. 
- Added life_coplevel 2 for Speedboat Minigun. 
- Removed Regular camo hunter. 
- Hunters are now fully black. 
- Moved Digi Green Hummingbird to rebels from civilians. 
- Moved Sheriff Hummingbird to civilians from police (which still have
ion/black). 
- Set vehicle chop shop prices at approximately half of their rental
price as per @Heavybob's suggestion [here](https://github.com/ArmaLife/Altis/commit/ab981a7d0146a573b3d2e0290626b68919ee6fdf). 
- Removed Fresnel black SUV from police. 
- Removed identical Fresnel black Offroad from police. 
- Added config for SDV. 
- Miscellaneous changes. 

##### fn_copLights, fn_sirenLights, fn_keyHandler, and fn_spawnVehicle:
- Added police lights to Hatchback (Sport), Hummingbird, and Ghosthawk. 
