### PR TITLE
Mission: Civ and medic slots update

### DIFF
--- a/Altis_Life.Altis/mission.sqm
+++ b/Altis_Life.Altis/mission.sqm
@@ -422,7 +422,7 @@ class Mission
 					special="NONE";
 					id=20;
 					side="CIV";
-					vehicle="C_man_polo_6_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -466,7 +466,7 @@ class Mission
 					special="NONE";
 					id=22;
 					side="CIV";
-					vehicle="C_man_polo_6_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -532,7 +532,7 @@ class Mission
 					special="NONE";
 					id=25;
 					side="CIV";
-					vehicle="C_man_polo_6_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -576,7 +576,7 @@ class Mission
 					special="NONE";
 					id=27;
 					side="CIV";
-					vehicle="C_man_polo_6_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -642,7 +642,7 @@ class Mission
 					special="NONE";
 					id=30;
 					side="CIV";
-					vehicle="C_man_polo_6_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -686,7 +686,7 @@ class Mission
 					special="NONE";
 					id=32;
 					side="CIV";
-					vehicle="C_man_polo_6_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -752,7 +752,7 @@ class Mission
 					special="NONE";
 					id=35;
 					side="CIV";
-					vehicle="C_man_polo_6_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -796,7 +796,7 @@ class Mission
 					special="NONE";
 					id=37;
 					side="CIV";
-					vehicle="C_man_polo_6_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -862,7 +862,7 @@ class Mission
 					special="NONE";
 					id=40;
 					side="CIV";
-					vehicle="C_man_polo_6_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -906,7 +906,7 @@ class Mission
 					special="NONE";
 					id=42;
 					side="CIV";
-					vehicle="C_man_polo_6_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -972,7 +972,7 @@ class Mission
 					special="NONE";
 					id=45;
 					side="CIV";
-					vehicle="C_man_polo_6_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1016,7 +1016,7 @@ class Mission
 					special="NONE";
 					id=47;
 					side="CIV";
-					vehicle="C_man_polo_6_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1082,7 +1082,7 @@ class Mission
 					special="NONE";
 					id=50;
 					side="CIV";
-					vehicle="C_man_polo_6_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1126,7 +1126,7 @@ class Mission
 					special="NONE";
 					id=52;
 					side="CIV";
-					vehicle="C_man_polo_6_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1192,7 +1192,7 @@ class Mission
 					special="NONE";
 					id=55;
 					side="CIV";
-					vehicle="C_man_polo_6_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1236,7 +1236,7 @@ class Mission
 					special="NONE";
 					id=57;
 					side="CIV";
-					vehicle="C_man_polo_6_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1280,7 +1280,7 @@ class Mission
 					special="NONE";
 					id=59;
 					side="CIV";
-					vehicle="C_man_polo_4_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1302,7 +1302,7 @@ class Mission
 					special="NONE";
 					id=60;
 					side="CIV";
-					vehicle="C_man_1_2_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1324,7 +1324,7 @@ class Mission
 					special="NONE";
 					id=61;
 					side="CIV";
-					vehicle="C_man_polo_1_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1346,7 +1346,7 @@ class Mission
 					special="NONE";
 					id=62;
 					side="CIV";
-					vehicle="C_man_1_3_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1368,7 +1368,7 @@ class Mission
 					special="NONE";
 					id=63;
 					side="CIV";
-					vehicle="C_man_1_3_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1390,7 +1390,7 @@ class Mission
 					special="NONE";
 					id=64;
 					side="CIV";
-					vehicle="C_man_polo_4_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1412,7 +1412,7 @@ class Mission
 					special="NONE";
 					id=65;
 					side="CIV";
-					vehicle="C_man_1_2_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1434,7 +1434,7 @@ class Mission
 					special="NONE";
 					id=66;
 					side="CIV";
-					vehicle="C_man_polo_1_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1456,7 +1456,7 @@ class Mission
 					special="NONE";
 					id=67;
 					side="CIV";
-					vehicle="C_man_1_3_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1478,7 +1478,7 @@ class Mission
 					special="NONE";
 					id=68;
 					side="CIV";
-					vehicle="C_man_1_3_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1500,7 +1500,7 @@ class Mission
 					special="NONE";
 					id=69;
 					side="CIV";
-					vehicle="C_man_polo_4_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1522,7 +1522,7 @@ class Mission
 					special="NONE";
 					id=70;
 					side="CIV";
-					vehicle="C_man_1_2_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1544,7 +1544,7 @@ class Mission
 					special="NONE";
 					id=71;
 					side="CIV";
-					vehicle="C_man_polo_1_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1566,7 +1566,7 @@ class Mission
 					special="NONE";
 					id=72;
 					side="CIV";
-					vehicle="C_man_1_3_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1588,7 +1588,7 @@ class Mission
 					special="NONE";
 					id=73;
 					side="CIV";
-					vehicle="C_man_1_3_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1610,7 +1610,7 @@ class Mission
 					special="NONE";
 					id=74;
 					side="CIV";
-					vehicle="C_man_1_3_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1632,7 +1632,7 @@ class Mission
 					special="NONE";
 					id=75;
 					side="CIV";
-					vehicle="C_man_1_3_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1654,7 +1654,7 @@ class Mission
 					special="NONE";
 					id=76;
 					side="CIV";
-					vehicle="C_man_1_3_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1676,7 +1676,7 @@ class Mission
 					special="NONE";
 					id=77;
 					side="CIV";
-					vehicle="C_man_1_3_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1698,7 +1698,7 @@ class Mission
 					special="NONE";
 					id=78;
 					side="CIV";
-					vehicle="C_man_1_3_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1720,7 +1720,7 @@ class Mission
 					special="NONE";
 					id=79;
 					side="CIV";
-					vehicle="C_man_1_3_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1742,7 +1742,7 @@ class Mission
 					special="NONE";
 					id=80;
 					side="CIV";
-					vehicle="C_man_1_3_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1764,7 +1764,7 @@ class Mission
 					special="NONE";
 					id=81;
 					side="CIV";
-					vehicle="C_man_1_3_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1786,7 +1786,7 @@ class Mission
 					special="NONE";
 					id=82;
 					side="CIV";
-					vehicle="C_man_1_3_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1808,7 +1808,7 @@ class Mission
 					special="NONE";
 					id=83;
 					side="CIV";
-					vehicle="C_man_1_3_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1830,12 +1830,12 @@ class Mission
 					special="NONE";
 					id=84;
 					side="CIV";
-					vehicle="C_man_1_3_F";
+					vehicle="C_man_1";
 					player="PLAYER COMMANDER";
 					leader=1;
 					skill=0.60000002;
-					text="civ_70";
-					description="Civ 70";
+					text="civ_66";
+					description="Civ 66";
 				};
 			};
 		};
@@ -1852,12 +1852,12 @@ class Mission
 					special="NONE";
 					id=85;
 					side="CIV";
-					vehicle="C_man_1_3_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
-					text="civ_69";
-					description="Civ 69";
+					text="civ_67";
+					description="Civ 67";
 				};
 			};
 		};
@@ -1874,7 +1874,7 @@ class Mission
 					special="NONE";
 					id=86;
 					side="CIV";
-					vehicle="C_man_1_3_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -1896,12 +1896,12 @@ class Mission
 					special="NONE";
 					id=87;
 					side="CIV";
-					vehicle="C_man_1_3_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
-					text="civ_67";
-					description="Civ 67";
+					text="civ_69";
+					description="Civ 69";
 				};
 			};
 		};
@@ -1918,12 +1918,12 @@ class Mission
 					special="NONE";
 					id=88;
 					side="CIV";
-					vehicle="C_man_1_3_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
-					text="civ_66";
-					description="Civ 66";
+					text="civ_70";
+					description="Civ 70";
 				};
 			};
 		};
@@ -1940,12 +1940,12 @@ class Mission
 					special="NONE";
 					id=89;
 					side="CIV";
-					vehicle="C_man_1_3_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
-					text="civ_75";
-					description="Civ 75";
+					text="civ_71";
+					description="Civ 71";
 				};
 			};
 		};
@@ -1962,12 +1962,12 @@ class Mission
 					special="NONE";
 					id=90;
 					side="CIV";
-					vehicle="C_man_1_3_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
-					text="civ_74";
-					description="Civ 74";
+					text="civ_72";
+					description="Civ 72";
 				};
 			};
 		};
@@ -1984,7 +1984,7 @@ class Mission
 					special="NONE";
 					id=91;
 					side="CIV";
-					vehicle="C_man_1_3_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
@@ -2006,12 +2006,12 @@ class Mission
 					special="NONE";
 					id=92;
 					side="CIV";
-					vehicle="C_man_1_3_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
-					text="civ_72";
-					description="Civ 72";
+					text="civ_74";
+					description="Civ 74";
 				};
 			};
 		};
@@ -2028,12 +2028,12 @@ class Mission
 					special="NONE";
 					id=93;
 					side="CIV";
-					vehicle="C_man_1_3_F";
+					vehicle="C_man_1";
 					player="PLAY CDG";
 					leader=1;
 					skill=0.60000002;
-					text="civ_71";
-					description="Civ 71";
+					text="civ_75";
+					description="Civ 75";
 				};
 			};
 		};
@@ -3428,7 +3428,7 @@ class Mission
 					leader=1;
 					skill=0.60000002;
 					text="medic_1";
-					description="EMS Medic";
+					description="WhiteListed - EMS Medic 1";
 				};
 				class Item1
 				{
@@ -3440,8 +3440,8 @@ class Mission
 					vehicle="B_medic_F";
 					player="PLAY CDG";
 					skill=0.60000002;
-					text="medic_3";
-					description="EMS Medic";
+					text="medic_2";
+					description="WhiteListed - EMS Medic 2";
 				};
 				class Item2
 				{
@@ -3453,8 +3453,8 @@ class Mission
 					vehicle="B_medic_F";
 					player="PLAY CDG";
 					skill=0.60000002;
-					text="medic_4";
-					description="EMS Medic";
+					text="medic_3";
+					description="WhiteListed - EMS Medic 3";
 				};
 				class Item3
 				{
@@ -3466,8 +3466,8 @@ class Mission
 					vehicle="B_medic_F";
 					player="PLAY CDG";
 					skill=0.60000002;
-					text="medic_2";
-					description="EMS Medic";
+					text="medic_4";
+					description="WhiteListed - EMS Medic 4";
 				};
 			};
 		};


### PR DESCRIPTION
###### mission.sqm
- All occurrences of `vehicle=` not equal to `C_man_1` changed to
`C_man_1`.
- Correctly ordered civilian and medic slots into ascending order.
- Changed medic slots' descriptions. 
