### PR TITLE
Suspending not allowed

### DIFF
--- a/Altis_Life.Altis/core/functions/fn_clearVehicleAmmo.sqf
+++ b/Altis_Life.Altis/core/functions/fn_clearVehicleAmmo.sqf
@@ -35,3 +35,4 @@ if(EQUAL(_veh,"B_Heli_Transport_01_F")) then
 clearWeaponCargoGlobal _vehicle;
 clearMagazineCargoGlobal _vehicle;
 clearItemCargoGlobal _vehicle;
+clearBackpackCargoGlobal _vehicle;

--- a/Altis_Life.Altis/mission.sqm
+++ b/Altis_Life.Altis/mission.sqm
@@ -3098,13 +3098,13 @@ class Mission
 				class Item84
 				{
 					position[]={14259.365,19.363842,16302.626};
-					azimut=160.00729;
+					azimut=160.007;
 					special="NONE";
 					id=181;
 					side="CIV";
 					vehicle="C_man_1";
 					skill=0.60000002;
-					init="this enableSimulation false; this allowDamage false; this addAction[localize""STR_Garage_Title"",  {   if(life_HC_isActive) then {	[getPlayerUID player,playerSide,""Air"",player] remoteExecCall [""HC_fnc_getVehicles"",HC_Life]; } else { [getPlayerUID player,playerSide,""Air"",player] remoteExecCall [""TON_fnc_getVehicles"",2];};  life_garage_type = ""Air""; createDialog ""Life_impound_menu"";   disableSerialization;   ctrlSetText[2802,""Fetching Vehicles....""];   life_garage_sp = ""air_g_1"";  }]; this addAction[localize""STR_MAR_Store_vehicle_in_Garage"",  {   private[""_nearVehicle""];   _nearVehicle = nearestObjects[(getPos (_this select 0)),[""Car"",""Ship"",""Air""],35] select 0;   if(isNil ""_nearVehicle"") exitWith {hint ""There isn't a vehicle near this NPC."";};   [_nearVehicle,false,(_this select 1)] remoteExecCall [""TON_fnc_vehicleStore"",2];   hint ""The server is trying to store the vehicle please wait...."";   life_garage_store = true;  },"""",0,false,false,"""",'!life_garage_store'];";
+					init="this enableSimulation false; this allowDamage false; this addAction[localize""STR_Garage_Title"",  {   if(life_HC_isActive) then { [getPlayerUID player,playerSide,""Air"",player] remoteExecCall [""HC_fnc_getVehicles"",HC_Life]; } else { [getPlayerUID player,playerSide,""Air"",player] remoteExecCall [""TON_fnc_getVehicles"",2];};  life_garage_type = ""Air""; createDialog ""Life_impound_menu"";   disableSerialization;   ctrlSetText[2802,""Fetching Vehicles....""];   life_garage_sp = ""air_g_1"";  }];   this addAction[localize""STR_MAR_Store_vehicle_in_Garage"",life_fnc_storeVehicle,"""",0,false,false,"""",'!life_garage_store'];";
 				};
 				class Item85
 				{


### PR DESCRIPTION
```
0:04:18 Suspending not allowed in this context
 0:04:18 Error in expression <> 0)) OR (_trunk3 select 0) > 0) then {
sleep 1200; 
_query = format["UPDATE veh>
 0:04:18   Error position: <sleep 1200; 
_query = format["UPDATE veh>
 0:04:18   Error Generic error in expression
 0:04:18 File life_server\Functions\Systems\fn_vehicleStore.sqf, line 123
 0:04:37 Suspending not allowed in this context
 0:04:37 Error in expression <> 0)) OR (_trunk3 select 0) > 0) then {
sleep 1200; 
_query = format["UPDATE veh>
 0:04:37   Error position: <sleep 1200; 
_query = format["UPDATE veh>
 0:04:37   Error Generic error in expression
 0:04:37 File life_server\Functions\Systems\fn_vehicleStore.sqf, line 123
```
Could be wrong but im only having this problem with the default mission.sqm and why not remove those pesky parachutes