### PR TITLE
HC Disabled by default.  HC_Required option

### DIFF
--- a/life_server/config.cpp
+++ b/life_server/config.cpp
@@ -16,6 +16,7 @@ class Life_Server_Settings {
 
 		/* HC Setting */
 		HC_Enabled = true;
+		HC_Required = false;
 	};
 };
 

--- a/life_server/config.cpp
+++ b/life_server/config.cpp
@@ -15,7 +15,7 @@ class Life_Server_Settings {
 		DebugMode = 0;
 
 		/* HC Setting */
-		HC_Enabled = true;
+		HC_Enabled = false;
 		HC_Required = false;
 	};
 };

--- a/life_server/init.sqf
+++ b/life_server/init.sqf
@@ -154,11 +154,11 @@ _rsb setVariable["bis_disabled_Door_1",1,true];
 _rsb allowDamage false;
 _dome allowDamage false;
 
-//if(EQUAL(EXTDB_SETTING(getNumber,"HC_Enabled"),0)) then {
+if(EQUAL(EXTDB_SETTING(getNumber,"HC_Required"),0)) then {
 	/* Tell clients that the server is ready and is accepting queries */
 	life_server_isReady = true;
 	PVAR_ALL("life_server_isReady");
-//};
+};
 
 if(EQUAL(EXTDB_SETTING(getNumber,"HC_Enabled"),0)) then {
 	/* Initialize hunting zone(s) */


### PR DESCRIPTION
Headless client should be disabled by default.

HC_Required setting added to give the option to require the headless for the server to be ready for players.