### PR TITLE
Vehicle Preview Adjustments

### DIFF
--- a/Altis_Life.Altis/core/shops/fn_vehicleShopInit3DPreview.sqf
+++ b/Altis_Life.Altis/core/shops/fn_vehicleShopInit3DPreview.sqf
@@ -41,7 +41,7 @@ life_preview_3D_vehicle_object = objNull;
 		// Rotation around the object.
 		while {life_preview_3D_vehicle_object == _object} do
 		{
-			_azimuthCam = _azimuthCam + 3.25;
+			_azimuthCam = _azimuthCam + .70;
 
 			life_preview_3D_vehicle_cam camSetPos (_object modelToWorld [_distanceCam * sin _azimuthCam, _distanceCam * cos _azimuthCam, _distanceCam * 0.33]);
 			life_preview_3D_vehicle_cam camCommit 0.05;


### PR DESCRIPTION
Slows the rate at which the previewed vehicle spins.

Currently it spins fast enough to make me feel sick.
I don't know how you can possibly preview more than like one vehicle without going insane..
This is still pretty quick though in my opinion. If the background was black and not clouds it'd be easier on the eyes as well. May create a bounding box like what Exile did...