### PR TITLE
Delete WeaponHolderSimulated on Death

### DIFF
--- a/Altis_Life.Altis/core/medical/fn_onPlayerKilled.sqf
+++ b/Altis_Life.Altis/core/medical/fn_onPlayerKilled.sqf
@@ -95,6 +95,9 @@ if(!isNull _killer && {_killer != _unit} && {side _killer != west} && {alive _ki
 
 life_save_gear = [player] call life_fnc_fetchDeadGear;
 
+_containers = nearestObjects[getPosATL player,["WeaponHolderSimulated"],5];
+{deleteVehicle _x;} foreach _containers;
+
 //Killed by cop stuff...
 if(side _killer == west && playerSide != west) then {
 	life_copRecieve = _killer;


### PR DESCRIPTION
Will address - https://github.com/ArmaLife/Altis/issues/439

Should be fixed. Could've sworn this was in here at one point in time...
I know it's in respawned, however that's obviously not called till you respawn. Meh.