### PR TITLE
TakeItem restrictions

### DIFF
--- a/Altis_Life.Altis/Config_Master.hpp
+++ b/Altis_Life.Altis/Config_Master.hpp
@@ -32,9 +32,6 @@ class Life_Settings {
     seize_headgear[] = { "H_Cap_police" }; //Any hats or helmets you want seized from players
     seize_minimum_rank = 2; //Required minimum CopLevel to be able to seize items from players
 
-    /* Medic related settings*/
-    allow_medic_weapons = true; // true allows medics to hold/use weapons - false disallows
-
     /* Revive system settings */
     revive_cops = true; //true to enable cops the ability to revive everyone or false for only medics/ems.
     revive_fee = 1500; //Revive fee that players have to pay and medics / EMS are rewarded
@@ -53,7 +50,13 @@ class Life_Settings {
     /* Player-related systems */
     enable_fatigue = true; //Set to false to disable the ARMA 3 fatigue system.
     total_maxWeight = 24; //Static variable for the maximum weight allowed without having a backpack
-    paycheck_period = 5; //Scaled in minutes
+
+    /* Item-related restrictions */
+    restrict_medic_weapons = true; //Set to false to allow medics to use any weapon -true will remove ANY weapon they attempt to use (primary,secondary,launcher)
+    restrict_clothingPickup = true; //Set to false to allow civilians to pickup/take any uniform (ground/crates/vehicles)
+    restrict_weaponPickup = false; //Set to false to allow civilians to pickup/take any weapon (ground/crates/vehicles)
+    restricted_uniforms[] = { "U_Rangemaster", "U_B_CombatUniform_mcam_tshirt", "U_B_CombatUniform_mcam_worn", "U_B_survival_uniform" };
+    restricted_weapons[] = { "hgun_P07_snds_F", "arifle_MX_F", "arifle_MXC_F" };
 
     /* Impound Variables */
     impound_car = 350; //Price for impounding cars
@@ -65,7 +68,8 @@ class Life_Settings {
     bank_civ = 3000; //Amount of cash on bank for new civillians
     bank_med = 6500; //Amount of cash on bank for new medics
 
-    /* Paycheck Amount */
+    /* Paycheck Settings */
+    paycheck_period = 5; //Scaled in minutes
     paycheck_cop = 500; //Payment for cops
     paycheck_civ = 350; //Payment for civillians
     paycheck_med = 450; //Payment for medics
@@ -91,7 +95,7 @@ class Life_Settings {
     vehicleShop_rentalOnly[] = { "B_MRAP_01_hmg_F", "B_G_Offroad_01_armed_F", "B_Boat_Armed_01_minigun_F" };
     vehicleShop_BuyMultiplier = 1.5;
     vehicleGarage_SellMultiplier = 0.75;
-    vehicleGarage_StorFeeMultiplier = 0.2;
+    vehicleGarage_StoreFeeMultiplier = 0.2;
     vehicleChopShop_Multiplier = 0.5;
 
     /* Job-related stuff */

--- a/Altis_Life.Altis/core/fn_initMedic.sqf
+++ b/Altis_Life.Altis/core/fn_initMedic.sqf
@@ -15,12 +15,9 @@ if((FETCH_CONST(life_medicLevel)) < 1 && (FETCH_CONST(life_adminlevel) == 0)) ex
 	sleep 35;
 };
 
-if(EQUAL(LIFE_SETTINGS(getNumber,"allow_medic_weapons"),0)) then
-{
-	[] spawn
-	{
-		while {true} do
-		{
+if(EQUAL(LIFE_SETTINGS(getNumber,"restrict_medic_weapons"),1)) then {
+	[] spawn {
+		while {true} do	{
 			waitUntil {sleep 3; currentWeapon player != ""};
 			removeAllWeapons player;
 		};

--- a/Altis_Life.Altis/core/functions/fn_onTakeItem.sqf
+++ b/Altis_Life.Altis/core/functions/fn_onTakeItem.sqf
@@ -2,16 +2,18 @@
 /*
 	File: fn_onTakeItem.sqf
 	Author: Bryan "Tonic" Boardwine
-	
+
 	Description:
 	Blocks the unit from taking something they should not have.
 */
-private["_unit","_item"];
+private["_unit","_item","_restrictedClothing","_restrictedWeapons"];
 _unit = [_this,0,ObjNull,[ObjNull]] call BIS_fnc_param;
 _container = [_this,1,ObjNull,[ObjNull]] call BIS_fnc_param;
 _item = [_this,2,"",[""]] call BIS_fnc_param;
 
 if(isNull _unit OR _item == "") exitWith {}; //Bad thingies?
+_restrictedClothing = LIFE_SETTINGS(getArray,"restricted_uniforms");
+_restrictedWeapons = LIFE_SETTINGS(getArray,"restricted_weapons");
 
 switch(playerSide) do
 {
@@ -21,9 +23,15 @@ switch(playerSide) do
 		};
 	};
 	case civilian: {
-		//Currently stoping the civilians from taking the Rangemaster clothing from medics or cops.
-		if(_item in ["U_Rangemaster"]) then {
-			[_item,false,false,false,false] call life_fnc_handleItem;
+		if(EQUAL(LIFE_SETTINGS(getNumber,"restrict_clothingPickup"),1)) then {
+			if(_item in _restrictedClothing) then {
+				[_item,false,false,false,false] call life_fnc_handleItem;
+			};
+		};
+		if(EQUAL(LIFE_SETTINGS(getNumber,"restrict_weaponPickup"),1)) then {
+			if(_item in _restrictedWeapons) then {
+				[_item,false,false,false,false] call life_fnc_handleItem;
+			};
 		};
 		if(_item in ["U_C_Poloshirt_blue","U_C_Poloshirt_burgundy","U_C_Poloshirt_stripped","U_C_Poloshirt_tricolour","U_C_Poloshirt_salmon","U_C_Poloshirt_redwhite","U_C_Commoner1_1"]) then {
 			[] call life_fnc_playerSkins;

--- a/Altis_Life.Altis/dialog/function/fn_garageLBChange.sqf
+++ b/Altis_Life.Altis/dialog/function/fn_garageLBChange.sqf
@@ -34,7 +34,7 @@ _retrievePrice = switch(playerSide) do {
 	case independent: {SEL(M_CONFIG(getArray,CONFIG_LIFE_VEHICLES,_classNameLife,"rentalprice"),2)};
 	case east: {SEL(M_CONFIG(getArray,CONFIG_LIFE_VEHICLES,_classNameLife,"rentalprice"),3)};
 };
-_multiplier = LIFE_SETTINGS(getNumber,"vehicleGarage_StorFeeMultiplier");
+_multiplier = LIFE_SETTINGS(getNumber,"vehicleGarage_StoreFeeMultiplier");
 _retrievePrice = _multiplier * _retrievePrice;
 
 _sellPrice = switch(playerSide) do {

--- a/Altis_Life.Altis/dialog/function/fn_unimpound.sqf
+++ b/Altis_Life.Altis/dialog/function/fn_unimpound.sqf
@@ -28,7 +28,7 @@ _price = switch(playerSide) do {
 	case independent: {SEL(M_CONFIG(getArray,CONFIG_LIFE_VEHICLES,_vehicleLife,"rentalprice"),2)};
 	case east: {SEL(M_CONFIG(getArray,CONFIG_LIFE_VEHICLES,_vehicleLife,"rentalprice"),3)};
 };
-_multiplier = LIFE_SETTINGS(getNumber,"vehicleGarage_StorFeeMultiplier");
+_multiplier = LIFE_SETTINGS(getNumber,"vehicleGarage_StoreFeeMultiplier");
 _price = _multiplier * _price;
 
 if(!(EQUAL(typeName _price,typeName 0)) OR _price < 1) then {_price = 1000};


### PR DESCRIPTION
Few things here:

1. Moved/Renamed the allow_medic_weapons to accompany the new restrictions section
2. Moved paycheck interval to the paycheck settings area
3. Changed "vehicleGarage_StorFeeMultiplier" in Master_Config to be "vehicleGarage_StoreFeeMultiplier" (note the "e")
4. Added 2 options that essentially are the same, just for beautification and separation purposes. It will allow you to define easily what items you don't want civilians to be able to pickup or take from inventories.

This is not meant to be by any means an anti-hack/cheat replacement. Simply to more so work with the seize script as I found out you can't pickup cop clothes. Some servers like that. This will make it easier for owners to decide if they want people to pick up cop/medic clothes.