### PR TITLE
ActionKeyHandler Revert/Fix

### DIFF
--- a/Altis_Life.Altis/core/actions/fn_escortAction.sqf
+++ b/Altis_Life.Altis/core/actions/fn_escortAction.sqf
@@ -1,19 +1,28 @@
 #include "..\..\script_macros.hpp"
 /*
 	File: fn_escortAction.sqf
-	Author: 
-	
-	Description:
-	
+	Author: Bryan "Tonic" Boardwine
+
+	Description: Attaches the desired person(_unit) to the player(player) and "escorts them".
 */
-private "_unit";
+private ["_unit"];
 _unit = [_this,0,ObjNull,[ObjNull]] call BIS_fnc_param;
 
+if(!isNull(player GVAR ["escortingPlayer",ObjNull])) exitWith {};
 if(isNil "_unit" OR isNull _unit OR !isPlayer _unit) exitWith {};
 if(!(side _unit in [civilian,independent])) exitWith {};
 if((player distance _unit > 3)) exitWith {};
 
 _unit attachTo [player,[0.1,1.1,0]];
+player SVAR ["escortingPlayer",_unit];
+player SVAR ["isEscorting",true];
 _unit SVAR ["transporting",false,true];
 _unit SVAR ["Escorting",true,true];
 player reveal _unit;
+
+[_unit] spawn {
+	_unit = _this select 0;
+	waitUntil {(!(_unit GVAR ["Escorting",false]))};
+	player SVAR ["escortingPlayer",nil];
+	player SVAR ["isEscorting",false];
+};

--- a/Altis_Life.Altis/core/actions/fn_stopEscorting.sqf
+++ b/Altis_Life.Altis/core/actions/fn_stopEscorting.sqf
@@ -1,15 +1,18 @@
+#include "..\..\script_macros.hpp"
 /*
 	File: fn_stopEscorting.sqf
-	Author: 
-	
+	Author: Bryan "Tonic" Boardwine
+
 	Description:
-	ASFSDFHAGFASF
+	Detaches player(_unit) from the Escorter(player) and sets them back down.
 */
 private["_unit"];
-_unit = [_this,0,ObjNull,[ObjNull]] call BIS_fnc_param;
-if(isNull _unit) exitWith {}; //Not valid
-if(!(_unit getVariable "Escorting")) exitWith {}; //He's not being Escorted.
+_unit = player GVAR ["escortingPlayer",objNull];
+if(isNull _unit) then {_unit = cursorTarget;}; //Emergency fallback.
+if(isNull _unit) exitWith {}; //Target not found even after using cursorTarget.
+if(!(_unit GVAR ["Escorting",false])) exitWith {}; //He's not being Escorted.
 if(side _unit != civilian) exitWith {}; //Not a civ
-if(isNull _unit) exitWith {}; //Not valid
 detach _unit;
-_unit setVariable["Escorting",false,true];
+_unit SVAR ["Escorting",false,true];
+player SVAR ["currentlyEscorting",nil];
+player SVAR ["isEscorting",false];

--- a/Altis_Life.Altis/core/cop/fn_copInteractionMenu.sqf
+++ b/Altis_Life.Altis/core/cop/fn_copInteractionMenu.sqf
@@ -19,16 +19,18 @@
 private["_display","_curTarget","_seizeRank","_Btn1","_Btn2","_Btn3","_Btn4","_Btn5","_Btn6","_Btn7","_Btn8"];
 
 disableSerialization;
-_curTarget = param [0,ObjNull,[ObjNull]];
+_curTarget = param [0,objNull,[objNull]];
 _seizeRank = LIFE_SETTINGS(getNumber,"seize_minimum_rank");
-if(isNull _curTarget) exitWith {closeDialog 0;}; //Bad target
+
+if(player GVAR ["Escorting", false]) then {
+	if(isNull _curTarget) exitWith {closeDialog 0;}; //Bad target
+	if(!isPlayer _curTarget && side _curTarget == civilian) exitWith {closeDialog 0;}; //Bad side check?
+	if(player distance _curTarget > 4 ) exitWith {closeDialog 0;}; // Prevents menu accessing from far distances.
+};
 
 if(!dialog) then {
 	createDialog "pInteraction_Menu";
 };
-
-if(!isPlayer _curTarget && side _curTarget == civilian) exitWith {closeDialog 0;}; //Bad side check?
-if(player distance _curTarget > 4 ) exitWith {closeDialog 0;}; // Prevents menu accessing from far distances.
 
 _display = findDisplay 37400;
 _Btn1 = _display displayCtrl Btn1;
@@ -40,6 +42,10 @@ _Btn6 = _display displayCtrl Btn6;
 _Btn7 = _display displayCtrl Btn7;
 _Btn8 = _display displayCtrl Btn8;
 life_pInact_curTarget = _curTarget;
+
+if((player getVariable["isEscorting",false])) then {
+	{ _x ctrlShow false; } forEach [_Btn1,_Btn2,_Btn3,_Btn5,_Btn6,_Btn7,_Btn8];
+};
 
 //Set Unrestrain Button
 _Btn1 ctrlSetText localize "STR_pInAct_Unrestrain";
@@ -54,9 +60,9 @@ _Btn3 ctrlSetText localize "STR_pInAct_SearchPlayer";
 _Btn3 buttonSetAction "[life_pInact_curTarget] spawn life_fnc_searchAction; closeDialog 0;";
 
 //Set Escort Button
-if((_curTarget getVariable["Escorting",false])) then {
+if((player getVariable["isEscorting",false])) then {
 	_Btn4 ctrlSetText localize "STR_pInAct_StopEscort";
-	_Btn4 buttonSetAction "[life_pInact_curTarget] call life_fnc_stopEscorting; [life_pInact_curTarget] call life_fnc_copInteractionMenu;";
+	_Btn4 buttonSetAction "[] call life_fnc_stopEscorting; closeDialog 0;";
 } else {
 	_Btn4 ctrlSetText localize "STR_pInAct_Escort";
 	_Btn4 buttonSetAction "[life_pInact_curTarget] call life_fnc_escortAction; closeDialog 0;";

--- a/Altis_Life.Altis/core/functions/fn_actionKeyHandler.sqf
+++ b/Altis_Life.Altis/core/functions/fn_actionKeyHandler.sqf
@@ -7,12 +7,15 @@
 	Master action key handler, handles requests for picking up various items and
 	interacting with other players (Cops = Cop Menu for unrestrain,escort,stop escort, arrest (if near cop hq), etc).
 */
-private["_curObject","_curTarget","_isWater","_CrateModelNames","_crate"];
-_curTarget = cursorTarget;
+private["_curObject","_isWater","_CrateModelNames","_crate"];
 _curObject = cursorObject;
 if(life_action_inUse) exitWith {}; //Action is in use, exit to prevent spamming.
 if(life_interrupted) exitWith {life_interrupted = false;};
 _isWater = surfaceIsWater (visiblePositionASL player);
+
+if((player getVariable["isEscorting",false])) exitWith {
+	[] call life_fnc_copInteractionMenu;
+};
 
 if(EQUAL(LIFE_SETTINGS(getNumber,"global_ATM"),1)) then{
 	//Check if the player is near an ATM.
@@ -90,44 +93,36 @@ if(_curObject isKindOf "Man" && {!alive _curObject} && !(_curObject GVAR["Revive
 	};
 };
 
-
 //If target is a player then check if we can use the cop menu.
 if(isPlayer _curObject && _curObject isKindOf "Man") then {
 	if((_curObject GVAR ["restrained",false]) && !dialog && playerSide == west) then {
 		[_curObject] call life_fnc_copInteractionMenu;
 	};
 } else {
-	//Lets check if target is a player with cursorTarget.
-	if(isPlayer _curTarget && _curTarget isKindOf "Man") then {
-		if((_curTarget GVAR ["restrained",false]) && !dialog && playerSide == west) then {
-			[_curTarget] call life_fnc_copInteractionMenu;
+	//OK, it wasn't a player so what is it?
+	private["_isVehicle","_miscItems","_money","_list"];
+
+	_list = ["landVehicle","Ship","Air"];
+	_isVehicle = if(KINDOF_ARRAY(_curObject,_list)) then {true} else {false};
+	_miscItems = ["Land_BottlePlastic_V1_F","Land_TacticalBacon_F","Land_Can_V3_F","Land_CanisterFuel_F","Land_Suitcase_F"];
+	_animalTypes = ["Salema_F","Ornate_random_F","Mackerel_F","Tuna_F","Mullet_F","CatShark_F","Turtle_F"];
+	_money = "Land_Money_F";
+
+	//It's a vehicle! open the vehicle interaction key!
+	if(_isVehicle) then {
+		if(!dialog) then {
+			if(player distance _curObject < SEL(SEL(boundingBox _curObject,1),0)+2) then {
+				[_curObject] call life_fnc_vInteractionMenu;
+			};
 		};
 	} else {
-		//OK, it wasn't a player so what is it?
-		private["_isVehicle","_miscItems","_money","_list"];
-
-		_list = ["landVehicle","Ship","Air"];
-		_isVehicle = if(KINDOF_ARRAY(_curObject,_list)) then {true} else {false};
-		_miscItems = ["Land_BottlePlastic_V1_F","Land_TacticalBacon_F","Land_Can_V3_F","Land_CanisterFuel_F","Land_Suitcase_F"];
-		_animalTypes = ["Salema_F","Ornate_random_F","Mackerel_F","Tuna_F","Mullet_F","CatShark_F","Turtle_F"];
-		_money = "Land_Money_F";
-
-		//It's a vehicle! open the vehicle interaction key!
-		if(_isVehicle) then {
-			if(!dialog) then {
-				if(player distance _curObject < SEL(SEL(boundingBox _curObject,1),0)+2) then {
-					[_curObject] call life_fnc_vInteractionMenu;
-				};
-			};
+		//OK, it wasn't a vehicle so let's see what else it could be?
+		if((typeOf _curObject) in _miscItems) then {
+			[_curObject,player,false] remoteExecCall ["TON_fnc_pickupAction",RSERV];
 		} else {
-			//OK, it wasn't a vehicle so let's see what else it could be?
-			if((typeOf _curObject) in _miscItems) then {
-				[_curObject,player,false] remoteExecCall ["TON_fnc_pickupAction",RSERV];
-			} else {
-				//It wasn't a misc item so is it money?
-				if(EQUAL((typeOf _curObject),_money) && {!(_curObject GVAR ["inUse",false])}) then {
-					[_curObject,player,true] remoteExecCall ["TON_fnc_pickupAction",RSERV];
-				};
+			//It wasn't a misc item so is it money?
+			if(EQUAL((typeOf _curObject),_money) && {!(_curObject GVAR ["inUse",false])}) then {
+				[_curObject,player,true] remoteExecCall ["TON_fnc_pickupAction",RSERV];
 			};
 		};
 	};

--- a/Altis_Life.Altis/core/medical/fn_onPlayerKilled.sqf
+++ b/Altis_Life.Altis/core/medical/fn_onPlayerKilled.sqf
@@ -24,7 +24,7 @@ _unit SVAR ["Revive",true,true];
 _unit SVAR ["name",profileName,true]; //Set my name so they can say my name.
 _unit SVAR ["restrained",false,true];
 _unit SVAR ["Escorting",false,true];
-_unit SVAR ["transporting",false,true]; //Why the fuck do I have this? Is it used?
+_unit SVAR ["transporting",false,true];
 _unit SVAR ["playerSurrender",false,true];
 _unit SVAR ["steam64id",(getPlayerUID player),true]; //Set the UID.
 
@@ -68,19 +68,19 @@ _unit spawn {
 //Make the killer wanted
 if(!isNull _killer && {_killer != _unit} && {side _killer != west} && {alive _killer}) then {
 	if(vehicle _killer isKindOf "LandVehicle") then {
-	
+
 		if(life_HC_isActive) then {
 			[getPlayerUID _killer,_killer GVAR ["realname",name _killer],"187V"] remoteExecCall ["HC_fnc_wantedAdd",HC_Life];
 		} else {
 			[getPlayerUID _killer,_killer GVAR ["realname",name _killer],"187V"] remoteExecCall ["life_fnc_wantedAdd",RSERV];
 		};
-		
+
 		//Get rid of this if you don't want automatic vehicle license removal.
 		if(!local _killer) then {
 			[2] remoteExecCall ["life_fnc_removeLicenses",_killer];
 		};
 	} else {
-	
+
 		if(life_HC_isActive) then {
 			[getPlayerUID _killer,_killer GVAR ["realname",name _killer],"187"] remoteExecCall ["HC_fnc_wantedAdd",HC_Life];
 		} else {

--- a/Altis_Life.Altis/core/medical/fn_onPlayerRespawn.sqf
+++ b/Altis_Life.Altis/core/medical/fn_onPlayerRespawn.sqf
@@ -18,7 +18,7 @@ _containers = nearestObjects[getPosATL _corpse,["WeaponHolderSimulated"],5]; //F
 //Set some vars on our new body.
 _unit SVAR ["restrained",false,true];
 _unit SVAR ["Escorting",false,true];
-_unit SVAR ["transporting",false,true]; //Again why the fuck am I setting this? Can anyone tell me?
+_unit SVAR ["transporting",false,true];
 _unit SVAR ["playerSurrender",false,true];
 _unit SVAR ["steam64id",steamid,true]; //Reset the UID.
 _unit SVAR ["realname",profileName,true]; //Reset the players name.


### PR DESCRIPTION
**Purpose:** To not use cursorTarget/Object on escorting to prevent the dialog from not popping up. This will now allow the menu to always show.

**NOTICE:** Tested the new menu and cop functions on the menu numerous times and various configurations...

**Changelog: **
_fn_escortAction.sqf_
-Added two new variables `escortingPlayer` & `isEscorting`
-Added a check to make it so the player can re-escort if something happens to the person being escorted. 

_fn_stopEscorting.sqf_
-Basically the above...  and added an emergency fall-back to cursorTarget that probably won't even work in the situations I could make up in my mind that this would ever be called. It was never called in any of my testing..

_fn_copInteractionMenu.sqf_
-Hides buttons on the menu to require that cops stop-escorting players before proceeding with other options. This is due to how the other scripts all still work with cursorTarget/Object. Maybe we'll change it all later. However, we should stop escorting players anyways, it'll eliminate a lot of potential bugs and errors that come with other scripts...

_fn_actionKeyHandler.sqf_
-Yeah.. pretty simple. Just reverted the change to cursorTarget... also changed it all to cursorObject.
-Made it so the escort menu pops up when you're escorting.. lol... wooo!

_fn_onPlayerKilled.sqf & fn_onPlayerRespawn.sqf_
-Just removed tonic's transporting comments... We now use it for anti-seat switching and stuff when transporting restrained players in police vehicles. Also when preventing to jump out I do believe.