### PR TITLE
M_Config Jail Settings -> Virtual Items & Seize Script

### DIFF
--- a/Altis_Life.Altis/Config_Master.hpp
+++ b/Altis_Life.Altis/Config_Master.hpp
@@ -72,6 +72,10 @@ class Life_Settings {
     restricted_uniforms[] = { "U_Rangemaster", "U_B_CombatUniform_mcam_tshirt", "U_B_CombatUniform_mcam_worn", "U_B_survival_uniform" };
     restricted_weapons[] = { "hgun_P07_snds_F", "arifle_MX_F", "arifle_MXC_F" };
 
+    /* Jail System Configurations */
+    jail_seize_vItems[] = { "spikeStrip","lockpick","goldbar","blastingcharge","boltcutter","defusekit","heroin_unprocessed","heroin_processed","cannabis","marijuana","cocaine_unprocessed","cocaine_processed","turtle_raw" }; //Define VIRTUAL items you want to be removed from players upon jailing here. Use "jail_seize_inventory" for Arma inventory items.
+    jail_seize_inventory = false; //Set to true to run the cop seize script on inmates. False will remove only weapons and magazines otherwise. (Basically used in case cops forget to seize items). [See Lines 106-111 below]
+
     /* Medical System Configurations */
     revive_cops = true; //true to enable cops the ability to revive everyone or false for only medics/ems.
     revive_fee = 1500; //Revive fee that players have to pay and medics only EMS(independent) are rewarded with this amount.

--- a/Altis_Life.Altis/core/civilian/fn_jail.sqf
+++ b/Altis_Life.Altis/core/civilian/fn_jail.sqf
@@ -2,10 +2,11 @@
 /*
 	File: fn_jail.sqf
 	Author: Bryan "Tonic" Boardwine
-	
+
 	Description:
 	Starts the initial process of jailing.
 */
+private ["_illegalItems"];
 params [
 	["_unit",objNull,[objNull]],
 	["_bad",false,[false]]
@@ -14,6 +15,7 @@ params [
 if(isNull _unit) exitWith {}; //Dafuq?
 if(_unit != player) exitWith {}; //Dafuq?
 if(life_is_arrested) exitWith {}; //Dafuq i'm already arrested
+_illegalItems = LIFE_SETTINGS(getArray,"jail_seize_vItems");
 
 player SVAR ["restrained",false,true];
 player SVAR ["Escorting",false,true];
@@ -40,12 +42,16 @@ if(player distance (getMarkerPos "jail_marker") > 40) then {
 	if(_amount > 0) then {
 		[false,_x,_amount] call life_fnc_handleInv;
 	};
-} forEach ["spikeStrip","lockpick","goldbar","blastingcharge","boltcutter","defusekit","heroin_unprocessed","heroin_processed","cannabis","marijuana","cocaine_unprocessed","cocaine_processed","turtle_raw"];
+} forEach _illegalItems;
 
 life_is_arrested = true;
 
-removeAllWeapons player;
-{player removeMagazine _x} forEach (magazines player);
+if(EQUAL(LIFE_SETTINGS(getNumber,"jail_seize_inventory"),1)) then {
+	[] spawn life_fnc_seizeClient;
+} else {
+	removeAllWeapons player;
+	{player removeMagazine _x} forEach (magazines player);
+};
 
 if(life_HC_isActive) then {
 	[player,_bad] remoteExecCall ["HC_fnc_jailSys",HC_Life];


### PR DESCRIPTION
This will add Master_config options to specify VIRTUAL items they want removed from players when they are jailed. Also the ability to run our cop seize scripts on players when jailed, otherwise it will just remove guns/magazines like before...

@Jawshy thanks for the inspiration when I saw you editing that yesterday :+1: 