### PR TITLE
Fix Cop Skins Error

### DIFF
--- a/Altis_Life.Altis/core/functions/fn_playerSkins.sqf
+++ b/Altis_Life.Altis/core/functions/fn_playerSkins.sqf
@@ -38,8 +38,10 @@ switch(playerSide) do {
 	case west: {
 		if(uniform player == "U_Rangemaster") then {
 			_skinName = "textures\cop_uniform.jpg";
-			if(EQUAL(LIFE_SETTINGS(getNumber,"cop_extendedSkins"),1) && FETCH_CONST(life_coplevel) >= 1 && FETCH_CONST(life_coplevel) <= 7) then {
+			if(EQUAL(LIFE_SETTINGS(getNumber,"cop_extendedSkins"),1)) then {
+				if(FETCH_CONST(life_coplevel) >= 1) then {
 					_skinName = ["textures\cop_uniform_",(FETCH_CONST(life_coplevel)),".jpg"] joinString "";
+				};
 			};
 			player setObjectTextureGlobal [0, _skinName];
 		};


### PR DESCRIPTION
@danielStuart14
You would get the follow error(HAVE TO LOAD AS COP): https://i.gyazo.com/3f300fc0b5333af1d24b93d95ff3a924.png

Removed the coplevel <= 7, since it shouldn't be above 7 due to SQL(enum) not allowing people to enter values higher than 7 unless the edit the field, in which they'd then have to edit this if we left a <= check anyways. 

So this way not only fixes the error, but will allow for players to simply add more uniforms and not have to edit this file, only their DB field.

Fixed the rpt erorr: https://i.gyazo.com/5e580ba49cd53e12840120c25657adf9.png