### PR TITLE
Vehicle System Settings

### DIFF
--- a/Altis_Life.Altis/Config_Master.hpp
+++ b/Altis_Life.Altis/Config_Master.hpp
@@ -94,15 +94,6 @@ class Life_Settings {
     delivery_points[] = { "dp_1", "dp_2", "dp_3", "dp_4", "dp_5", "dp_6", "dp_7", "dp_8", "dp_9", "dp_10", "dp_11", "dp_12", "dp_13", "dp_14", "dp_15", "dp_15", "dp_16", "dp_17", "dp_18", "dp_19", "dp_20", "dp_21", "dp_22", "dp_23", "dp_24", "dp_25" };
     fuelTank_winMultiplier = 1; //Win Multiplier in FuelTank Missions. Increase for greater payout. Default = 1
 
-    /* Vehicle System Configurations */
-    vehicle_infiniteRepair = false; //Set to true for unlimited repairs with 1 toolkit. False will remove toolkit upon use.
-    vehicleShop_rentalOnly[] = { "B_MRAP_01_hmg_F", "B_G_Offroad_01_armed_F", "B_Boat_Armed_01_minigun_F" }; //Vehicles that can only be rented and not purchased. (Last only for the session)
-    vehicleShop_BuyMultiplier = 1.5; //Buy Price = rental price * vehicleShop_BuyMultipler
-    vehicleGarage_SellMultiplier = 0.75;
-    vehicleGarage_StoreFeeMultiplier = 0.2;
-    vehicleChopShop_Multiplier = 0.5;
-
-/* Cop Related Settings */
     /* Search & Seizure System Configurations */
     seize_exempt[] = { "Binocular", "ItemWatch", "ItemCompass", "ItemGPS", "ItemMap", "NVGoggles", "FirstAidKit", "ToolKit", "Chemlight_red", "Chemlight_yellow", "Chemlight_green", "Chemlight_blue", "optic_ACO_grn_smg" }; //Arma items that will not get seized from player inventories
     seize_uniform[] = { "U_Rangemaster" }; //Any specific uniforms you want to be seized from players
@@ -111,9 +102,32 @@ class Life_Settings {
     seize_minimum_rank = 2; //Required minimum CopLevel to be able to seize items from players
 
     /* Vehicle System Configurations */
-    impound_car = 350; //Payout for impounding cars
-    impound_boat = 250; //Payout for impounding boats
-    impound_air = 850; //Payout for impounding helicopters / planes
+    chopShop_vehicles[] = { "Car", "Air" }; //Vehicles that can be chopped. (Can add: "Ship" and possibly more -> look at the BI wiki...)
+    vehicle_infiniteRepair = false; //Set to true for unlimited repairs with 1 toolkit. False will remove toolkit upon use.
+    vehicleShop_rentalOnly[] = { "B_MRAP_01_hmg_F", "B_G_Offroad_01_armed_F", "B_Boat_Armed_01_minigun_F" }; //Vehicles that can only be rented and not purchased. (Last only for the session)
+
+        /* Vehicle Purchase Prices */
+        vehicle_purchase_multiplier_CIVILIAN = 1; //Civilian Vehicle Buy Price = Config_Vehicle price * multiplier
+        vehicle_purchase_multiplier_COP = .5; //Cop Vehicle Buy Price = Config_Vehicle price * multiplier
+        vehicle_purchase_multiplier_MEDIC = .75; //Medic Vehicle Buy Price = Config_Vehicle price * multiplier
+        vehicle_purchase_multiplier_OPFOR = -1; // -- NOT IN USE -- Simply left in for east support.
+
+        /* Vehicle Purchase Prices */
+        vehicle_rental_multiplier_CIVILIAN = .80; //Civilian Vehicle Rental Price = Config_Vehicle price * multiplier
+        vehicle_rental_multiplier_COP = .3; //Cop Vehicle Rental Price = Config_Vehicle price * multiplier
+        vehicle_rental_multiplier_MEDIC = .55; //Medic Vehicle Rental Price = Config_Vehicle price * multiplier
+        vehicle_rental_multiplier_OPFOR = -1; // -- NOT IN USE -- Simply left in for east support.
+
+        /* Vehicle Sell Prices */
+        vehicle_sell_multiplier_CIVILIAN = .5; //Civilian Vehicle Garage Sell Price = Vehicle Buy Price * multiplier
+        vehicle_sell_multiplier_COP = .5; //Cop Vehicle Garage Sell Price = Vehicle Buy Price * multiplier
+        vehicle_sell_multiplier_MEDIC = .5; //Medic Vehicle Garage Sell Price = Vehicle Buy Price * multiplier
+        vehicle_sell_multiplier_OPFOR = -1; // -- NOT IN USE -- Simply left in for east support.
+
+        /* "Other" Vehicle Prices */
+        vehicle_chopShop_multiplier = .25; //Chop Shop price for vehicles. TO AVOID EXPLOITS NEVER SET HIGHER THAN A PURCHASE/RENTAL multipler!   Payout = Config_vehicle Price * multiplier
+        vehicle_storage_fee_multiplier = .2; //Pull from garage cost --> Cost takes the playersides Buy Price * multiplier
+        vehicle_cop_impound_multiplier = .1; //TO AVOID EXPLOITS NEVER SET HIGHER THAN A PURCHASE/RENTAL multipler!   Payout = Config_vehicle Price * multiplier
 
 /* Wanted System Settings *
     /* crimes[] = {String, Bounty, Code} */

--- a/Altis_Life.Altis/Config_Vehicles.hpp
+++ b/Altis_Life.Altis/Config_Vehicles.hpp
@@ -131,9 +131,20 @@ class CarShops {
 class LifeCfgVehicles {
     /*
     *    Vehicle Configs (Contains textures and other stuff)
-    *       1: ARRAY (Rental Price)
-    *         Ex: { 200, 200 , 200 , 200 } //civilian, west, independent, east
-    *       2: ARRAY (license required)
+    *
+    *    "price" is the price before any multipliers set in Master_Config are applied.
+    *
+    *    Default Multiplier Values & Calculations:
+    *       Civilian [Purchase, Sell]: [1.0, 0.5]
+    *       Cop [Purchase, Sell]: [0.5, 0.5]
+    *       Medic [Purchase, Sell]: [0.75, 0.5]
+    *       ChopShop: Payout = price * 0.25
+    *       GarageSell: Payout = price * [0.5, 0.5, 0.5, -1]
+    *       Cop Impound: Payout = price * 0.1
+    *       Pull Vehicle from Garage: Cost = price * [1, 0.5, 0.75, -1] * [0.5, 0.5, 0.5, -1]
+    *           -- Pull Vehicle & GarageSell Array Explanation = [civ,cop,medic,east]
+    *
+    *       1: ARRAY (license required)
     *         Ex: { "driver", "" , "" , "" } //civilian, west, independent, east
     *         licenses[] = { {"CIV"}, {"COP"}, {"MEDIC"}, {"EAST"} };
     *    Textures config follows { Texture Name, side, {texture(s)path}}
@@ -148,49 +159,49 @@ class LifeCfgVehicles {
     class Default {
         vItemSpace = -1;
         licenses[] = { {""}, {""}, {""}, {""} };
-        rentalprice[] = { -1, -1, -1, -1 };
+        price = -1;
         textures[] = {};
     };
 
     class I_Truck_02_medical_F {
         vItemSpace = 150;
         licenses[] = { {""}, {""}, {""}, {""} };
-        rentalprice[] = { -1, -1, 25000, -1 };
+        price = 25000;
         textures[] = {};
     };
 
     class O_Truck_03_medical_F {
         vItemSpace = 200;
         licenses[] = { {""}, {""}, {""}, {""} };
-        rentalprice[] = { -1, -1, 45000, -1 };
+        price = 45000;
         textures[] = {};
     };
 
     class B_Truck_01_medical_F {
         vItemSpace = 250;
         licenses[] = { {""}, {""}, {""}, {""} };
-        rentalprice[] = { -1, -1, 60000, -1 };
+        price = 60000;
         textures[] = {};
     };
 
     class C_Rubberboat {
         vItemSpace = 45;
         licenses[] = { {"boat"}, {""}, {""}, {""} };
-        rentalprice[] = { 5000, -1, -1, -1 };
+        price = 5000;
         textures[] = { };
     };
 
     class B_Heli_Transport_01_F {
         vItemSpace = 200;
         licenses[] = { {""}, {"cAir"}, {""}, {""} };
-        rentalprice[] = { -1, 200000, -1, -1 };
+        price = 200000;
         textures[] = {};
     };
 
     class B_MRAP_01_hmg_F {
         vItemSpace = 100;
         licenses[] = { {""}, {""}, {""}, {""} };
-        rentalprice[] = { -1, 750000, -1, -1 };
+        price = 750000;
         textures[] = {
             { "Black", "cop", {
                 "#(argb,8,8,3)color(0.05,0.05,0.05,1)",
@@ -203,105 +214,105 @@ class LifeCfgVehicles {
     class B_Boat_Armed_01_minigun_F {
         vItemSpace = 175;
         licenses[] = { {""}, {"cg"}, {""}, {""} };
-        rentalprice[] = { -1, 75000, -1, -1 };
+        price = 75000;
         textures[] = { };
     };
 
     class B_Boat_Transport_01_F {
         vItemSpace = 45;
         licenses[] = { {""}, {"cg"}, {""}, {""} };
-        rentalprice[] = { -1, 3000, -1, -1 };
+        price = 3000;
         textures[] = { };
     };
 
     class O_Truck_03_transport_F {
         vItemSpace = 285;
         licenses[] = { {"trucking"}, {""}, {""}, {""} };
-        rentalprice[] = { 200000, -1, -1, -1 };
+        price = 200000;
         textures[] = { };
     };
 
     class O_Truck_03_device_F {
         vItemSpace = 350;
         licenses[] = { {"trucking"}, {""}, {""}, {""} };
-        rentalprice[] = { 450000, -1, -1, -1 };
+        price = 450000;
         textures[] = { };
     };
 
     class Land_CargoBox_V1_F {
         vItemSpace = 5000;
         licenses[] = { {""}, {""}, {""}, {""} };
-        rentalprice[] = { -1, -1, -1, -1 };
+        price = -1;
         textures[] = {};
     };
 
     class Box_IND_Grenades_F {
         vItemSpace = 350;
         licenses[] = { {""}, {""}, {""}, {""} };
-        rentalprice[] = { -1, -1, -1, -1 };
+        price = -1;
         textures[] = {};
     };
 
     class B_supplyCrate_F {
         vItemSpace = 700;
         licenses[] = { {""}, {""}, {""}, {""} };
-        rentalprice[] = { -1, -1, -1, -1 };
+        price = -1;
         textures[] = {};
     };
 
     class B_G_Offroad_01_F {
         vItemSpace = 65;
         licenses[] = { {""}, {""}, {""}, {""} };
-        rentalprice[] = { 12500, -1, -1, -1 };
+        price = 12500;
         textures[] = { };
     };
 
     class B_G_Offroad_01_armed_F {
         vItemSpace = 65;
         licenses[] = { {"rebel"}, {""}, {""}, {""} };
-        rentalprice[] = { 750000, -1, -1, -1 };
+        price = 750000;
         textures[] = { };
     };
 
     class C_Boat_Civil_01_F {
         vItemSpace = 85;
         licenses[] = { {"boat"}, {""}, {""}, {""} };
-        rentalprice[] = { 22000, -1, -1, -1 };
+        price = 22000;
         textures[] = { };
     };
 
     class C_Boat_Civil_01_police_F {
         vItemSpace = 85;
         licenses[] = { {""}, {"cg"}, {""}, {""} };
-        rentalprice[] = { -1, 20000, -1, -1 };
+        price = 20000;
         textures[] = { };
     };
 
     class B_Truck_01_box_F {
         vItemSpace = 450;
         licenses[] = { {"trucking"}, {""}, {""}, {""} };
-        rentalprice[] = { 350000, -1, -1, -1 };
+        price = 350000;
         textures[] = { };
     };
 
     class B_Truck_01_transport_F {
         vItemSpace = 325;
         licenses[] = { {"trucking"}, {""}, {""}, {""} };
-        rentalprice[] = { 275000, -1, -1, -1 };
+        price = 275000;
         textures[] = { };
     };
 
     class O_MRAP_02_F {
         vItemSpace = 60;
         licenses[] = { {"driver"}, {""}, {""}, {""} };
-        rentalprice[] = { 150000, -1, -1, -1 };
+        price = 150000;
         textures[] = { };
     };
 
     class C_Offroad_01_F {
         vItemSpace = 65;
         licenses[] = { {"driver"}, {""}, {""}, {""} };
-        rentalprice[] = { 12500, 5000, 10000, -1 };
+        price = 12500;
         textures[] = {
             { "Red", "civ", {
                 "\A3\soft_F\Offroad_01\Data\offroad_01_ext_co.paa",
@@ -339,14 +350,14 @@ class LifeCfgVehicles {
     class C_Kart_01_Blu_F {
         vItemSpace = 20;
         licenses[] = { {"driver"}, {""}, {""}, {""} };
-        rentalprice[] = { 15000, -1, -1, -1 };
+        price = 15000;
         textures[] = {};
     };
 /*
 To edit another information in this classes you can use this exemple.
 class C_Kart_01_Fuel_F : C_Kart_01_Blu_F{
     vItemSpace = 40;
-    rentalprice[] = { 25000, -1, -1, -1 };
+    price = ;
 };
 
 will modify the virtual space and the price of the vehicle, but other information such as license and textures will pick up the vehicle declare at : Vehicle {};
@@ -358,7 +369,7 @@ will modify the virtual space and the price of the vehicle, but other informatio
     class C_Hatchback_01_sport_F {
         vItemSpace = 45;
         licenses[] = { {"driver"}, {""}, {""}, {""} };
-        rentalprice[] = { 40000, 30000, -1, -1 };
+        price = 40000;
         textures[] = {
             { "Red", "civ", {
                 "\a3\soft_f_gamma\Hatchback_01\data\hatchback_01_ext_sport01_co.paa"
@@ -387,7 +398,7 @@ will modify the virtual space and the price of the vehicle, but other informatio
     class B_Quadbike_01_F {
         vItemSpace = 25;
         licenses[] = { {"driver"}, {""}, {""}, {""} };
-        rentalprice[] = { 2500, -1, -1, -1 };
+        price = 2500;
         textures[] = {
             { "Brown", "cop", {
                 "\A3\Soft_F\Quadbike_01\Data\Quadbike_01_co.paa"
@@ -422,7 +433,7 @@ will modify the virtual space and the price of the vehicle, but other informatio
     class I_Truck_02_covered_F {
         vItemSpace = 250;
         licenses[] = { {"trucking"}, {""}, {""}, {""} };
-        rentalprice[] = { 100000, -1, -1, -1 };
+        price = 100000;
         textures[] = {
             { "Orange", "civ", {
                 "\A3\Soft_F_Beta\Truck_02\data\truck_02_kab_co.paa",
@@ -437,7 +448,7 @@ will modify the virtual space and the price of the vehicle, but other informatio
     class I_Truck_02_transport_F {
         vItemSpace = 200;
         licenses[] = { {"trucking"}, {""}, {""}, {""} };
-        rentalprice[] = { 75000, -1, -1, -1 };
+        price = 75000;
         textures[] = {
             { "Orange", "civ", {
                 "\A3\Soft_F_Beta\Truck_02\data\truck_02_kab_co.paa",
@@ -452,14 +463,14 @@ will modify the virtual space and the price of the vehicle, but other informatio
     class O_Truck_03_covered_F {
         vItemSpace = 300;
         licenses[] = { {"trucking"}, {""}, {""}, {""} };
-        rentalprice[] = { 250000, -1, -1, -1 };
+        price = 250000;
         textures[] = {};
     };
 
     class C_Hatchback_01_F {
         vItemSpace = 40;
         licenses[] = { {"driver"}, {""}, {""}, {""} };
-        rentalprice[] = { 9500, -1, -1, -1 };
+        price = 9500;
         textures[] = {
             { "Beige", "civ", {
                 "\a3\soft_f_gamma\Hatchback_01\data\hatchback_01_ext_base01_co.paa"
@@ -491,7 +502,7 @@ will modify the virtual space and the price of the vehicle, but other informatio
     class C_SUV_01_F {
         vItemSpace = 50;
         licenses[] = { {"driver"}, {""}, {""}, {""} };
-        rentalprice[] = { 30000, 20000, -1, -1 };
+        price = 30000;
         textures[] = {
             { "Dark Red", "civ", {
                 "\a3\soft_f_gamma\SUV_01\Data\suv_01_ext_co.paa"
@@ -511,7 +522,7 @@ will modify the virtual space and the price of the vehicle, but other informatio
     class C_Van_01_transport_F {
         vItemSpace = 100;
         licenses[] = { {"driver"}, {""}, {""}, {""} };
-        rentalprice[] = { 45000, -1, -1, -1 };
+        price = 45000;
         textures[] = {
             { "White", "civ", {
                 "\a3\soft_f_gamma\Van_01\Data\van_01_ext_co.paa"
@@ -525,7 +536,7 @@ will modify the virtual space and the price of the vehicle, but other informatio
     class C_Van_01_box_F {
         vItemSpace = 150;
         licenses[] = { {"trucking"}, {""}, {""}, {""} };
-        rentalprice[] = { 60000, -1, -1, -1 };
+        price = 60000;
         textures[] = {
             { "White", "civ", {
                 "\a3\soft_f_gamma\Van_01\Data\van_01_ext_co.paa"
@@ -539,7 +550,7 @@ will modify the virtual space and the price of the vehicle, but other informatio
     class B_MRAP_01_F {
         vItemSpace = 65;
         licenses[] = { {""}, {""}, {""}, {""} };
-        rentalprice[] = { -1, 30000, -1, -1 };
+        price = 30000;
         textures[] = {
             { "Black", "cop", {
                 "#(argb,8,8,3)color(0.05,0.05,0.05,1)",
@@ -551,7 +562,7 @@ will modify the virtual space and the price of the vehicle, but other informatio
      class B_Heli_Light_01_stripped_F {
         vItemSpace = 90;
         licenses[] = { {""}, {""}, {""}, {""} };
-        rentalprice[] = { 325000, -1, -1, -1 };
+        price = 275000;
         textures[] = {
             { "Rebel Digital", "reb", {
                 "\a3\air_f\Heli_Light_01\Data\Skins\heli_light_01_ext_digital_co.paa"
@@ -562,7 +573,7 @@ will modify the virtual space and the price of the vehicle, but other informatio
     class B_Heli_Light_01_F {
         vItemSpace = 90;
         licenses[] = { {"pilot"}, {"cAir"}, {"mAir"}, {""} };
-        rentalprice[] = { 275000, 75000, 50000, -1 };
+        price = 245000;
         textures[] = {
             { "Police", "cop", {
                 "\a3\air_f\Heli_Light_01\Data\heli_light_01_ext_ion_co.paa"
@@ -614,13 +625,13 @@ will modify the virtual space and the price of the vehicle, but other informatio
 
     class C_Heli_Light_01_civil_F : B_Heli_Light_01_F {
         vItemSpace = 75;
-        rentalprice[] = { 245000, 55000, 40000, -1 };
+        price = 245000;
     };
 
     class O_Heli_Light_02_unarmed_F {
         vItemSpace = 210;
         licenses[] = { {"pilot" }, {""}, {"mAir"}, {""} };
-        rentalprice[] = { 750000, -1, 75000, -1 };
+        price = 750000;
         textures[] = {
             { "Black", "cop", {
                 "\a3\air_f\Heli_Light_02\Data\heli_light_02_ext_co.paa"
@@ -643,7 +654,7 @@ will modify the virtual space and the price of the vehicle, but other informatio
     class B_SDV_01_F {
         vItemSpace = 50;
         licenses[] = { {"boat"}, {"cg"}, {""}, {""} };
-        rentalprice[] = { 150000, 100000, -1, -1 };
+        price = 150000;
         textures[] = {};
     };
 
@@ -651,7 +662,7 @@ will modify the virtual space and the price of the vehicle, but other informatio
         vItemSpace = 20;
         vFuelSpace = 19500;
         licenses[] = { {"trucking"}, {""}, {""}, {""} };
-        rentalprice[] = { 120000, -1, -1, -1 };
+        price = 120000;
         textures[] = {
             { "White", "civ", {
                 "\A3\soft_f_gamma\Van_01\data\van_01_ext_co.paa",
@@ -668,7 +679,7 @@ will modify the virtual space and the price of the vehicle, but other informatio
         vItemSpace = 40;
         vFuelSpace = 42000;
         licenses[] = { {"trucking"}, {""}, {""}, {""} };
-        rentalprice[] = { 200000, -1, -1, -1 };
+        price = 200000;
         textures[] = {
             { "White", "civ", {
                 "\A3\Soft_F_Beta\Truck_02\data\truck_02_kab_co.paa",
@@ -681,7 +692,7 @@ will modify the virtual space and the price of the vehicle, but other informatio
         vItemSpace = 50;
         vFuelSpace = 50000;
         licenses[] = { {"trucking"}, {""}, {""}, {""} };
-        rentalprice[] = { 250000, -1, -1, -1 };
+        price = 250000;
         textures[] = {};
     };
 };

--- a/Altis_Life.Altis/core/cop/fn_copInteractionMenu.sqf
+++ b/Altis_Life.Altis/core/cop/fn_copInteractionMenu.sqf
@@ -53,7 +53,7 @@ _Btn1 buttonSetAction "[life_pInact_curTarget] call life_fnc_unrestrain; closeDi
 
 //Set Check Licenses Button
 _Btn2 ctrlSetText localize "STR_pInAct_checkLicenses";
-_Btn2 buttonSetAction "[player] remoteExecCall [""life_fnc_licenseCheck"",life_pInact_curTarget];";
+_Btn2 buttonSetAction "[player] remoteExecCall [""life_fnc_licenseCheck"",life_pInact_curTarget]; closeDialog 0;";
 
 //Set Search Button
 _Btn3 ctrlSetText localize "STR_pInAct_SearchPlayer";
@@ -73,10 +73,10 @@ _Btn5 ctrlSetText localize "STR_pInAct_TicketBtn";
 _Btn5 buttonSetAction "[life_pInact_curTarget] call life_fnc_ticketAction;";
 
 _Btn6 ctrlSetText localize "STR_pInAct_Arrest";
-_Btn6 buttonSetAction "[life_pInact_curTarget] call life_fnc_arrestAction;";
+_Btn6 buttonSetAction "[life_pInact_curTarget] call life_fnc_arrestAction; closeDialog 0;";
 
 _Btn7 ctrlSetText localize "STR_pInAct_PutInCar";
-_Btn7 buttonSetAction "[life_pInact_curTarget] call life_fnc_putInCar;";
+_Btn7 buttonSetAction "[life_pInact_curTarget] call life_fnc_putInCar; closeDialog 0;";
 
 //SeizeWeapons Button
 _Btn8 ctrlSetText localize "STR_pInAct_Seize";

--- a/Altis_Life.Altis/core/housing/fn_sellHouse.sqf
+++ b/Altis_Life.Altis/core/housing/fn_sellHouse.sqf
@@ -40,6 +40,7 @@ if(_action) then {
 	_house SVAR ["uid",nil,true];
 
 	BANK = BANK + (round((_houseCfg select 0)/2));
+	[1] call SOCK_fnc_updatePartial;
 	_index = life_vehicles find _house;
 
 	if(EQUAL(LIFE_SETTINGS(getNumber,"player_advancedLog"),1)) then {

--- a/Altis_Life.Altis/core/shops/fn_chopShopMenu.sqf
+++ b/Altis_Life.Altis/core/shops/fn_chopShopMenu.sqf
@@ -6,10 +6,14 @@
 	Description:
 	Opens & initializes the chop shop menu.
 */
+private["_control","_price","_price","_chopMultiplier","chopable","_nearUnits"];
 if(life_action_inUse) exitWith {hint localize "STR_NOTF_ActionInProc"};
+if(playerSide != civilian) exitWith {hint localize "STR_NOTF_notAllowed"};
 disableSerialization;
-private["_nearVehicles","_control"];
-_nearVehicles = nearestObjects [getMarkerPos (_this select 3),["Car","Truck"],25];
+_chopable = LIFE_SETTINGS(getArray,"chopShop_vehicles");
+_nearVehicles = nearestObjects [getMarkerPos (_this select 3),_chopable,25];
+_nearUnits = (nearestObjects[player,["Man"],5]) arrayIntersect playableUnits;
+if(count _nearUnits > 1) exitWith {hint localize "STR_NOTF_PlayerNear"};
 
 life_chopShop = SEL(_this,3);
 //Error check
@@ -29,14 +33,10 @@ _control = CONTROL(39400,39402);
 			diag_log format["%1: LifeCfgVehicles class doesn't exist",_className];
 		};
 
-		_price = switch(playerSide) do {
-			case civilian: {SEL(M_CONFIG(getArray,CONFIG_LIFE_VEHICLES,_classNameLife,"rentalprice"),0)};
-			case west: {SEL(M_CONFIG(getArray,CONFIG_LIFE_VEHICLES,_classNameLife,"rentalprice"),1)};
-			case independent: {SEL(M_CONFIG(getArray,CONFIG_LIFE_VEHICLES,_classNameLife,"rentalprice"),2)};
-			case east: {SEL(M_CONFIG(getArray,CONFIG_LIFE_VEHICLES,_classNameLife,"rentalprice"),3)};
-		};
-		_multiplier = LIFE_SETTINGS(getNumber,"vehicleChopShop_multiplier");
-		_price = _multiplier * _price;
+		_price = M_CONFIG(getNumber,CONFIG_LIFE_VEHICLES,_classNameLife,"price");
+		_chopMultiplier = LIFE_SETTINGS(getNumber,"vehicle_chopShop_multiplier");
+
+		_price = _price * _chopMultiplier;
 		if(!isNil "_price" && EQUAL(count crew _x,0)) then {
 			_control lbAdd _displayName;
 			_control lbSetData [(lbSize _control)-1,str(_forEachIndex)];

--- a/Altis_Life.Altis/core/shops/fn_chopShopSell.sqf
+++ b/Altis_Life.Altis/core/shops/fn_chopShopSell.sqf
@@ -7,12 +7,13 @@
 	Sells the selected vehicle off.
 */
 disableSerialization;
-private["_control","_price","_vehicle","_nearVehicles","_price2"];
+private["_control","_price","_vehicle","_nearVehicles","_price2","_chopable"];
 _control = CONTROL(39400,39402);
 _price = _control lbValue (lbCurSel _control);
 _vehicle = _control lbData (lbCurSel _control);
 _vehicle = call compile format["%1", _vehicle];
-_nearVehicles = nearestObjects [getMarkerPos life_chopShop,["Car","Truck"],25];
+_chopable = LIFE_SETTINGS(getArray,"chopShop_vehicles");
+_nearVehicles = nearestObjects [getMarkerPos life_chopShop,_chopable,25];
 _vehicle = SEL(_nearVehicles,_vehicle);
 if(isNull _vehicle) exitWith {};
 

--- a/Altis_Life.Altis/core/shops/fn_vehicleShopLBChange.sqf
+++ b/Altis_Life.Altis/core/shops/fn_vehicleShopLBChange.sqf
@@ -9,7 +9,7 @@
 	displays various bits of information about the vehicle.
 */
 disableSerialization;
-private["_control","_index","_className","_classNameLife","_basePrice","_vehicleInfo","_colorArray","_ctrl","_trunkSpace","_maxspeed","_horsepower","_passengerseats","_fuel","_armor","_multiplier"];
+private["_control","_index","_className","_classNameLife","_initalPrice","_buyMultiplier","_rentMultiplier","_vehicleInfo","_colorArray","_ctrl","_trunkSpace","_maxspeed","_horsepower","_passengerseats","_fuel","_armor"];
 _control = _this select 0;
 _index = _this select 1;
 
@@ -18,11 +18,25 @@ _className = _control lbData _index;
 _classNameLife = _className;
 _vIndex = _control lbValue _index;
 
-_basePrice = switch(playerSide) do {
-	case civilian: {SEL(M_CONFIG(getArray,CONFIG_LIFE_VEHICLES,_classNameLife,"rentalprice"),0)};
-	case west: {SEL(M_CONFIG(getArray,CONFIG_LIFE_VEHICLES,_classNameLife,"rentalprice"),1)};
-	case independent: {SEL(M_CONFIG(getArray,CONFIG_LIFE_VEHICLES,_classNameLife,"rentalprice"),2)};
-	case east: {SEL(M_CONFIG(getArray,CONFIG_LIFE_VEHICLES,_classNameLife,"rentalprice"),3)};
+_initalPrice = M_CONFIG(getNumber,CONFIG_LIFE_VEHICLES,_classNameLife,"price");
+
+switch(playerSide) do {
+	case civilian: {
+		_buyMultiplier = LIFE_SETTINGS(getNumber,"vehicle_purchase_multiplier_CIVILIAN");
+		_rentMultiplier = LIFE_SETTINGS(getNumber,"vehicle_rental_multiplier_CIVILIAN");
+	};
+	case west: {
+		_buyMultiplier = LIFE_SETTINGS(getNumber,"vehicle_purchase_multiplier_COP");
+		_rentMultiplier = LIFE_SETTINGS(getNumber,"vehicle_rental_multiplier_COP");
+	};
+	case independent: {
+		_buyMultiplier = LIFE_SETTINGS(getNumber,"vehicle_purchase_multiplier_MEDIC");
+		_rentMultiplier = LIFE_SETTINGS(getNumber,"vehicle_rental_multiplier_MEDIC");
+	};
+	case east: {
+		_buyMultiplier = LIFE_SETTINGS(getNumber,"vehicle_purchase_multiplier_OPFOR");
+		_rentMultiplier = LIFE_SETTINGS(getNumber,"vehicle_rental_multiplier_OPFOR");
+	};
 };
 
 _vehicleInfo = [_className] call life_fnc_fetchVehInfo;
@@ -33,26 +47,25 @@ _passengerseats = _vehicleInfo select 10;
 _fuel = _vehicleInfo select 12;
 _armor = _vehicleInfo select 9;
 [_className] call life_fnc_vehicleShop3DPreview;
-_multiplier = LIFE_SETTINGS(getNumber,"vehicleShop_BuyMultiplier");
 
 ctrlShow [2330,true];
 (CONTROL(2300,2303)) ctrlSetStructuredText parseText format[
-(localize "STR_Shop_Veh_UI_Rental")+ " <t color='#8cff9b'>$%1</t><br/>" +
-(localize "STR_Shop_Veh_UI_Ownership")+ " <t color='#8cff9b'>$%2</t><br/>" +
-(localize "STR_Shop_Veh_UI_MaxSpeed")+ " %3 km/h<br/>" +
-(localize "STR_Shop_Veh_UI_HPower")+ " %4<br/>" +
-(localize "STR_Shop_Veh_UI_PSeats")+ " %5<br/>" +
-(localize "STR_Shop_Veh_UI_Trunk")+ " %6<br/>" +
-(localize "STR_Shop_Veh_UI_Fuel")+ " %7<br/>" +
-(localize "STR_Shop_Veh_UI_Armor")+ " %8",
-[_basePrice] call life_fnc_numberText,
-[round(_basePrice * _multiplier)] call life_fnc_numberText,
-_maxspeed,
-_horsepower,
-_passengerseats,
-if(_trunkSpace == -1) then {"None"} else {_trunkSpace},
-_fuel,
-_armor
+	(localize "STR_Shop_Veh_UI_Rental")+ " <t color='#8cff9b'>$%1</t><br/>" +
+	(localize "STR_Shop_Veh_UI_Ownership")+ " <t color='#8cff9b'>$%2</t><br/>" +
+	(localize "STR_Shop_Veh_UI_MaxSpeed")+ " %3 km/h<br/>" +
+	(localize "STR_Shop_Veh_UI_HPower")+ " %4<br/>" +
+	(localize "STR_Shop_Veh_UI_PSeats")+ " %5<br/>" +
+	(localize "STR_Shop_Veh_UI_Trunk")+ " %6<br/>" +
+	(localize "STR_Shop_Veh_UI_Fuel")+ " %7<br/>" +
+	(localize "STR_Shop_Veh_UI_Armor")+ " %8",
+	[round(_initalPrice * _rentMultiplier)] call life_fnc_numberText,
+	[round(_initalPrice * _buyMultiplier)] call life_fnc_numberText,
+	_maxspeed,
+	_horsepower,
+	_passengerseats,
+	if(_trunkSpace == -1) then {"None"} else {_trunkSpace},
+	_fuel,
+	_armor
 ];
 
 _ctrl = CONTROL(2300,2304);
@@ -75,10 +88,12 @@ _colorArray = M_CONFIG(getArray,CONFIG_LIFE_VEHICLES,_classNameLife,"textures");
 
 _numberindexcolor = 0;
 _numberindexcolorarray = [];
+
 for "_i" from 0 to (count(_colorArray) - 1) do {
 	_numberindexcolorarray pushBack _numberindexcolor;
 	_numberindexcolor = _numberindexcolor + 1;
 };
+
 _indexrandom = _numberindexcolorarray call BIS_fnc_selectRandom;
 _ctrl lbSetCurSel _indexrandom;
 
@@ -95,4 +110,5 @@ if((lbSize _ctrl)-1 != -1) then {
 } else {
 	ctrlShow[2304,false];
 };
+
 true;

--- a/Altis_Life.Altis/core/vehicle/fn_vInteractionMenu.sqf
+++ b/Altis_Life.Altis/core/vehicle/fn_vInteractionMenu.sqf
@@ -52,7 +52,7 @@ if(playerSide == west) then {
 	if(count crew _curTarget == 0) then {_Btn4 ctrlEnable false;};
 
 	_Btn5 ctrlSetText localize "STR_vInAct_Impound";
-	_Btn5 buttonSetAction "[life_vInact_curTarget] spawn life_fnc_impoundAction;";
+	_Btn5 buttonSetAction "[life_vInact_curTarget] spawn life_fnc_impoundAction; closeDialog 0;";
 
 	if(_curTarget isKindOf "Ship") then {
 		_Btn6 ctrlSetText localize "STR_vInAct_PushBoat";

--- a/Altis_Life.Altis/dialog/function/fn_garageLBChange.sqf
+++ b/Altis_Life.Altis/dialog/function/fn_garageLBChange.sqf
@@ -7,7 +7,7 @@
 	Can't be bothered to answer it.. Already deleted it by accident..
 */
 disableSerialization;
-private["_control","_index","_className","_classNameLife","_dataArr","_vehicleColor","_vehicleInfo","_trunkSpace","_sellPrice","_retrievePrice","_multiplier"];
+private["_control","_index","_className","_classNameLife","_dataArr","_vehicleColor","_vehicleInfo","_trunkSpace","_sellPrice","_retrievePrice","_sellMultiplier","_price","_storageFee","_purchasePrice"];
 _control = SEL(_this,0);
 _index = SEL(_this,1);
 
@@ -28,26 +28,32 @@ if(isNil "_vehicleColor") then {_vehicleColor = "Default";};
 _vehicleInfo = [_className] call life_fnc_fetchVehInfo;
 _trunkSpace = [_className] call life_fnc_vehicleWeightCfg;
 
-_retrievePrice = switch(playerSide) do {
-	case civilian: {SEL(M_CONFIG(getArray,CONFIG_LIFE_VEHICLES,_classNameLife,"rentalprice"),0)};
-	case west: {SEL(M_CONFIG(getArray,CONFIG_LIFE_VEHICLES,_classNameLife,"rentalprice"),1)};
-	case independent: {SEL(M_CONFIG(getArray,CONFIG_LIFE_VEHICLES,_classNameLife,"rentalprice"),2)};
-	case east: {SEL(M_CONFIG(getArray,CONFIG_LIFE_VEHICLES,_classNameLife,"rentalprice"),3)};
-};
-_multiplier = LIFE_SETTINGS(getNumber,"vehicleGarage_StoreFeeMultiplier");
-_retrievePrice = _multiplier * _retrievePrice;
+_price = M_CONFIG(getNumber,CONFIG_LIFE_VEHICLES,_classNameLife,"price");
+_storageFee = LIFE_SETTINGS(getNumber,"vehicle_storage_fee_multiplier");
 
-_sellPrice = switch(playerSide) do {
-	case civilian: {SEL(M_CONFIG(getArray,CONFIG_LIFE_VEHICLES,_classNameLife,"rentalprice"),0)};
-	case west: {SEL(M_CONFIG(getArray,CONFIG_LIFE_VEHICLES,_classNameLife,"rentalprice"),1)};
-	case independent: {SEL(M_CONFIG(getArray,CONFIG_LIFE_VEHICLES,_classNameLife,"rentalprice"),2)};
-	case east: {SEL(M_CONFIG(getArray,CONFIG_LIFE_VEHICLES,_classNameLife,"rentalprice"),3)};
+switch(playerSide) do {
+	case civilian: {
+		_purchasePrice = _price * LIFE_SETTINGS(getNumber,"vehicle_purchase_multiplier_CIVILIAN");
+		_sellMultiplier = LIFE_SETTINGS(getNumber,"vehicle_sell_multiplier_CIVILIAN");
+	};
+	case west: {
+		_purchasePrice = _price * LIFE_SETTINGS(getNumber,"vehicle_purchase_multiplier_COP");
+		_sellMultiplier = LIFE_SETTINGS(getNumber,"vehicle_sell_multiplier_COP");
+	};
+	case independent: {
+		_purchasePrice = _price * LIFE_SETTINGS(getNumber,"vehicle_purchase_multiplier_MEDIC");
+		_sellMultiplier = LIFE_SETTINGS(getNumber,"vehicle_sell_multiplier_MEDIC");
+	};
+	case east: {
+		_purchasePrice = _price * LIFE_SETTINGS(getNumber,"vehicle_purchase_multiplier_OPFOR");
+		_sellMultiplier = LIFE_SETTINGS(getNumber,"vehicle_sell_multiplier_OPFOR");
+	};
 };
-_multiplier = LIFE_SETTINGS(getNumber,"vehicleGarage_SellMultiplier");
-_sellPrice = _multiplier * _sellPrice;
+_retrievePrice = _purchasePrice * _storageFee;
+_sellPrice = _purchasePrice * _sellMultiplier;
 
-if(!(EQUAL(typeName _sellPrice,typeName 0)) OR _sellPrice < 1) then {_sellPrice = 1000};
-if(!(EQUAL(typeName _retrievePrice,typeName 0)) OR _retrievePrice < 1) then {_retrievePrice = 1000};
+if(!(EQUAL(typeName _sellPrice,typeName 0)) OR _sellPrice < 1) then {_sellPrice = 500;};
+if(!(EQUAL(typeName _retrievePrice,typeName 0)) OR _retrievePrice < 1) then {_retrievePrice = 500;};
 
 (CONTROL(2800,2803)) ctrlSetStructuredText parseText format[
 	(localize "STR_Shop_Veh_UI_RetrievalP")+ " <t color='#8cff9b'>$%1</t><br/>

--- a/Altis_Life.Altis/dialog/function/fn_sellGarage.sqf
+++ b/Altis_Life.Altis/dialog/function/fn_sellGarage.sqf
@@ -6,7 +6,7 @@
 	Description:
 	Sells a vehicle from the garage.
 */
-private["_vehicle","_vehicleLife","_vid","_pid","_unit","_sellPrice","_multiplier"];
+private["_vehicle","_vehicleLife","_vid","_pid","_sellPrice","_multiplier","_price"];
 disableSerialization;
 if(EQUAL(lbCurSel 2802,-1)) exitWith {hint localize "STR_Global_NoSelection"};
 _vehicle = lbData[2802,(lbCurSel 2802)];
@@ -14,7 +14,6 @@ _vehicle = (call compile format["%1",_vehicle]) select 0;
 _vehicleLife = _vehicle;
 _vid = lbValue[2802,(lbCurSel 2802)];
 _pid = steamid;
-_unit = player;
 
 if(isNil "_vehicle") exitWith {hint localize "STR_Garage_Selection_Error"};
 if((time - life_action_delay) < 1.5) exitWith {hint localize "STR_NOTF_ActionDelay";};
@@ -23,16 +22,17 @@ if(!isClass (missionConfigFile >> CONFIG_LIFE_VEHICLES >> _vehicleLife)) then {
 	diag_log format["%1: LifeCfgVehicles class doesn't exist",_vehicle];
 };
 
-_sellPrice = switch(playerSide) do {
-	case civilian: {SEL(M_CONFIG(getArray,CONFIG_LIFE_VEHICLES,_vehicleLife,"rentalprice"),0)};
-	case west: {SEL(M_CONFIG(getArray,CONFIG_LIFE_VEHICLES,_vehicleLife,"rentalprice"),1)};
-	case independent: {SEL(M_CONFIG(getArray,CONFIG_LIFE_VEHICLES,_vehicleLife,"rentalprice"),2)};
-	case east: {SEL(M_CONFIG(getArray,CONFIG_LIFE_VEHICLES,_vehicleLife,"rentalprice"),3)};
+_price = M_CONFIG(getNumber,CONFIG_LIFE_VEHICLES,_vehicleLife,"price");
+switch(playerSide) do {
+	case civilian: {_multiplier = LIFE_SETTINGS(getNumber,"vehicle_sell_multiplier_CIVILIAN");};
+	case west: {_multiplier = LIFE_SETTINGS(getNumber,"vehicle_sell_multiplier_COP");};
+	case independent: {_multiplier = LIFE_SETTINGS(getNumber,"vehicle_sell_multiplier_MEDIC");};
+	case east: {_multiplier = LIFE_SETTINGS(getNumber,"vehicle_sell_multiplier_OPFOR");};
 };
-_multiplier = LIFE_SETTINGS(getNumber,"vehicleGarage_SellMultiplier");
-_sellPrice = _multiplier * _sellPrice;
 
-if(!(EQUAL(typeName _sellPrice,typeName 0)) OR _sellPrice < 1) then {_sellPrice = 1000};
+_sellPrice = _price * _multiplier;
+
+if(!(EQUAL(typeName _sellPrice,typeName 0)) OR _sellPrice < 1) then {_sellPrice = 500;};
 
 if(life_HC_isActive) then {
 	[_vid,_pid,_sellPrice,player,life_garage_type] remoteExecCall ["HC_fnc_vehicleDelete",HC_Life];
@@ -42,6 +42,7 @@ if(life_HC_isActive) then {
 
 hint format[localize "STR_Garage_SoldCar",[_sellPrice] call life_fnc_numberText];
 ADD(BANK,_sellPrice);
+[1] call SOCK_fnc_updatePartial;
 
 if(EQUAL(LIFE_SETTINGS(getNumber,"player_advancedLog"),1)) then {
 	if(EQUAL(LIFE_SETTINGS(getNumber,"battlEye_friendlyLogging"),1)) then {

--- a/Altis_Life.Altis/dialog/function/fn_sellGarage.sqf
+++ b/Altis_Life.Altis/dialog/function/fn_sellGarage.sqf
@@ -6,7 +6,7 @@
 	Description:
 	Sells a vehicle from the garage.
 */
-private["_vehicle","_vehicleLife","_vid","_pid","_sellPrice","_multiplier","_price"];
+private["_vehicle","_vehicleLife","_vid","_pid","_sellPrice","_multiplier","_price","_purchasePrice"];
 disableSerialization;
 if(EQUAL(lbCurSel 2802,-1)) exitWith {hint localize "STR_Global_NoSelection"};
 _vehicle = lbData[2802,(lbCurSel 2802)];
@@ -24,13 +24,25 @@ if(!isClass (missionConfigFile >> CONFIG_LIFE_VEHICLES >> _vehicleLife)) then {
 
 _price = M_CONFIG(getNumber,CONFIG_LIFE_VEHICLES,_vehicleLife,"price");
 switch(playerSide) do {
-	case civilian: {_multiplier = LIFE_SETTINGS(getNumber,"vehicle_sell_multiplier_CIVILIAN");};
-	case west: {_multiplier = LIFE_SETTINGS(getNumber,"vehicle_sell_multiplier_COP");};
-	case independent: {_multiplier = LIFE_SETTINGS(getNumber,"vehicle_sell_multiplier_MEDIC");};
-	case east: {_multiplier = LIFE_SETTINGS(getNumber,"vehicle_sell_multiplier_OPFOR");};
+	case civilian: {
+		_multiplier = LIFE_SETTINGS(getNumber,"vehicle_sell_multiplier_CIVILIAN");
+		_purchasePrice = _price * LIFE_SETTINGS(getNumber,"vehicle_purchase_multiplier_CIVILIAN");
+	};
+	case west: {
+		_multiplier = LIFE_SETTINGS(getNumber,"vehicle_sell_multiplier_COP");
+		_purchasePrice = _price * LIFE_SETTINGS(getNumber,"vehicle_purchase_multiplier_COP");
+	};
+	case independent: {
+		_multiplier = LIFE_SETTINGS(getNumber,"vehicle_sell_multiplier_MEDIC");
+		_purchasePrice = _price * LIFE_SETTINGS(getNumber,"vehicle_purchase_multiplier_MEDIC");
+	};
+	case east: {
+		_multiplier = LIFE_SETTINGS(getNumber,"vehicle_sell_multiplier_OPFOR");
+		_purchasePrice = _price * LIFE_SETTINGS(getNumber,"vehicle_purchase_multiplier_OPFOR");
+	};
 };
 
-_sellPrice = _price * _multiplier;
+_sellPrice = _purchasePrice * _multiplier;
 
 if(!(EQUAL(typeName _sellPrice,typeName 0)) OR _sellPrice < 1) then {_sellPrice = 500;};
 

--- a/Altis_Life.Altis/dialog/function/fn_unimpound.sqf
+++ b/Altis_Life.Altis/dialog/function/fn_unimpound.sqf
@@ -6,7 +6,7 @@
 	Description:
 	Yeah... Gets the vehicle from the garage.
 */
-private["_vehicle","_vehicleLife","_vid","_pid","_unit","_price","_multiplier"];
+private["_vehicle","_vehicleLife","_vid","_pid","_unit","_price","_price","_storageFee","_purchasePrice"];
 disableSerialization;
 if(EQUAL(lbCurSel 2802,-1)) exitWith {hint localize "STR_Global_NoSelection"};
 _vehicle = lbData[2802,(lbCurSel 2802)];
@@ -22,37 +22,34 @@ if(!isClass (missionConfigFile >> CONFIG_LIFE_VEHICLES >> _vehicleLife)) then {
 	diag_log format["%1: LifeCfgVehicles class doesn't exist",_vehicle];
 };
 
-_price = switch(playerSide) do {
-	case civilian: {SEL(M_CONFIG(getArray,CONFIG_LIFE_VEHICLES,_vehicleLife,"rentalprice"),0)};
-	case west: {SEL(M_CONFIG(getArray,CONFIG_LIFE_VEHICLES,_vehicleLife,"rentalprice"),1)};
-	case independent: {SEL(M_CONFIG(getArray,CONFIG_LIFE_VEHICLES,_vehicleLife,"rentalprice"),2)};
-	case east: {SEL(M_CONFIG(getArray,CONFIG_LIFE_VEHICLES,_vehicleLife,"rentalprice"),3)};
+_price = M_CONFIG(getNumber,CONFIG_LIFE_VEHICLES,_vehicleLife,"price");
+_storageFee = LIFE_SETTINGS(getNumber,"vehicle_storage_fee_multiplier");
+
+switch(playerSide) do {
+	case civilian: {_purchasePrice = _price * LIFE_SETTINGS(getNumber,"vehicle_purchase_multiplier_CIVILIAN");};
+	case west: {_purchasePrice = _price * LIFE_SETTINGS(getNumber,"vehicle_purchase_multiplier_COP");};
+	case independent: {_purchasePrice = _price * LIFE_SETTINGS(getNumber,"vehicle_purchase_multiplier_MEDIC");};
+	case east: {_purchasePrice = _price * LIFE_SETTINGS(getNumber,"vehicle_purchase_multiplier_OPFOR");};
 };
-_multiplier = LIFE_SETTINGS(getNumber,"vehicleGarage_StoreFeeMultiplier");
-_price = _multiplier * _price;
+_price = _purchasePrice * _storageFee;
 
 if(!(EQUAL(typeName _price,typeName 0)) OR _price < 1) then {_price = 1000};
 if(BANK < _price) exitWith {hint format[(localize "STR_Garage_CashError"),[_price] call life_fnc_numberText];};
 
 if(EQUAL(typeName life_garage_sp,typeName [])) then {
-
 	if(life_HC_isActive) then {
 		[_vid,_pid,SEL(life_garage_sp,0),_unit,_price,SEL(life_garage_sp,1),_spawntext] remoteExec ["HC_fnc_spawnVehicle",HC_Life];
 	} else {
 		[_vid,_pid,SEL(life_garage_sp,0),_unit,_price,SEL(life_garage_sp,1),_spawntext] remoteExec ["TON_fnc_spawnVehicle",RSERV];
 	};
-
 } else {
 	if(life_garage_sp in ["medic_spawn_1","medic_spawn_2","medic_spawn_3"]) then {
-
 		if(life_HC_isActive) then {
 			[_vid,_pid,life_garage_sp,_unit,_price,0,_spawntext] remoteExec ["HC_fnc_spawnVehicle",HC_Life];
 		} else {
 			[_vid,_pid,life_garage_sp,_unit,_price,_spawntext] remoteExec ["TON_fnc_spawnVehicle",RSERV];
 		};
-
 	} else {
-
 		if(life_HC_isActive) then {
 			[_vid,_pid,(getMarkerPos life_garage_sp),_unit,_price,markerDir life_garage_sp,_spawntext] remoteExec ["HC_fnc_spawnVehicle",HC_Life];
 		} else {
@@ -63,4 +60,5 @@ if(EQUAL(typeName life_garage_sp,typeName [])) then {
 
 hint localize "STR_Garage_SpawningVeh";
 SUB(BANK,_price);
+[1] call SOCK_fnc_updatePartial;
 closeDialog 0;

--- a/Altis_Life.Altis/mission.sqm
+++ b/Altis_Life.Altis/mission.sqm
@@ -34523,7 +34523,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.60000002;
-						init="this allowDamage false; this enableSimulation false; this addAction[localize""STR_ChopShop_Title"",life_fnc_chopShopMenu,""chop_shop_1""];";
+						init="this allowDamage false; this enableSimulation false; this addAction[localize""STR_ChopShop_Title"",life_fnc_chopShopMenu,""chop_shop_1"",1.5,false,false,"""",'vehicle player == player && player distance _target < 3.5'];";
 					};
 					id=1040;
 					type="C_man_1";
@@ -34582,7 +34582,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.60000002;
-						init="this allowDamage false; this enableSimulation false; this addAction[localize""STR_ChopShop_Title"",life_fnc_chopShopMenu,""chop_shop_4""];";
+						init="this allowDamage false; this enableSimulation false; this addAction[localize""STR_ChopShop_Title"",life_fnc_chopShopMenu,""chop_shop_4"",1.5,false,false,"""",'vehicle player == player && player distance _target < 3.5'];";
 					};
 					id=1041;
 					type="C_man_1";
@@ -34641,7 +34641,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.60000002;
-						init="this allowDamage false; this enableSimulation false; this addAction[localize""STR_ChopShop_Title"",life_fnc_chopShopMenu,""chop_shop_2""];";
+						init="this allowDamage false; this enableSimulation false; this addAction[localize""STR_ChopShop_Title"",life_fnc_chopShopMenu,""chop_shop_2"",1.5,false,false,"""",'vehicle player == player && player distance _target < 3.5'];";
 					};
 					id=1042;
 					type="C_man_1";
@@ -34700,7 +34700,7 @@ class Mission
 					class Attributes
 					{
 						skill=0.60000002;
-						init="this allowDamage false; this enableSimulation false; this addAction[localize""STR_ChopShop_Title"",life_fnc_chopShopMenu,""chop_shop_3""];";
+						init="this allowDamage false; this enableSimulation false; this addAction[localize""STR_ChopShop_Title"",life_fnc_chopShopMenu,""chop_shop_3"",1.5,false,false,"""",'vehicle player == player && player distance _target < 3.5'];";
 					};
 					id=1043;
 					type="C_man_1";

--- a/Altis_Life.Altis/stringtable.xml
+++ b/Altis_Life.Altis/stringtable.xml
@@ -491,6 +491,9 @@
       <Original>Hit spacebar for place Container</Original>
       <French>Appuyez sur espace pour placer le container</French>
     </Key>
+    <Key ID="STR_NOTF_notAllowed">
+      <Original>Your faction is not allowed to chop vehicles!</Original>
+    </Key>
     <Key ID="STR_NOTF_Pickaxe">
       <Original>A pickaxe is required</Original>
       <German>Eine Spitzhacke wird benötigt.</German>
@@ -2102,9 +2105,9 @@
       <Portuguese>%1 apreendeu %3 de %2</Portuguese>
       <Polish>%1 usunął %2's %3</Polish>
     </Key>
-	<Key ID="STR_NOTF_OwnImpounded">
-      <Original>You payed %2 $ for Impounding your own %1</Original>
-      <German>Du hast %2 $ bezahlt, weil du dein eigenen %1 beschlagnahmt hast.</German>
+	  <Key ID="STR_NOTF_OwnImpounded">
+      <Original>You paid $%1 for impounding your own %2</Original>
+      <German>Du hast %1 $ bezahlt, weil du dein eigenen %2 beschlagnahmt hast.</German>
     </Key>
     <Key ID="STR_NOTF_AbortESC">
       <Original>Abort available in %1</Original>
@@ -2227,10 +2230,7 @@
       <Polish>W pobliżu nie ma pojazdu...</Polish>
     </Key>
     <Key ID="STR_NOTF_PlayerNear">
-      <Original>You can't open trunk while a player is near!</Original>
-      <German>Du kannst deinen Kofferaum nicht öffnen wenn ein anderer Spieler zu nah dran ist!</German>
-      <Portuguese>Você não pode abrir o inventário enquanto estiver perto de um jogador!</Portuguese>
-      <Polish>Nie możesz otworzyć wyposażenia gdy inny gracz jest w pobliżu!</Polish>
+      <Original>You can't chop a vehicle while a player is near!</Original>
     </Key>
     <Key ID="STR_NOTF_Restrained">
       <Original>%1 was restrained by %2</Original>


### PR DESCRIPTION
**Purpose:** Basically to fix potential issues regarding vehicle costs/impounds/chops/etc. Also, to add a large amount of new features and defines for specifics.

**Background Issue:** The prior system would take the vehicle costs from the array, so if you tried to chopShop a cop only vehicle such as the HMG, you wouldn't get any money.

**_Config_Master.hpp_**
-Added the ability to specify kindOf vehicles to chop, so you don't have to dig in the files for it
--Added ability to chop aircraft
-Added numerous vehicle configs that are faction specific
**--You now will be able to set buy prices and rental prices specific to the playerSide!**

**_Config_Vehicles.hpp_**
-rentalPrice array is now a single number and is simply "price". By default it is what civilians will pay to BUY a vehicle.

**_fn_impoundAction.sqf_**
-Impound payout is now based on the type of vehicle being impounded. NOTE: this is NOT side specific. - https://github.com/ArmaLife/Altis/issues/503

**_fn_copInteractionMenu.sqf_**
-Added a few closeDialogs... No reason to leave it open when you've just arrested someone or put them in the car. Don't be lazy, plus this can cause some issues.

**_fn_sellHouse.sqf_**
-When you sell a house, your bank information is now sync'd.

**_fn_chopShopMenu.sqf_**
-Only civilians can now chop only chop vehicles... Why would cops need to use an illegal chop shop when they have the ability to impound?!
-**Exploit Fix:**If another player is within 5 meters of the player they cannot chop a vehicle, this will prevent players from chopping the same vehicle at the same time.
-You can now chop any vehicle, not only vehicles with prices specified for your side. Before if you chopped a COP Only vehicle as civilian and it didn't have a price listed for civilian side, you'd get nothing...
-Added the ability to specify vehicle kinds in the Master_Config

**_fn_chopShopSell.sqf_**
-Added the ability to specify vehicle kinds in the Master_Config

**_fn_vehicleShopBuy.sqf_**
-Side specific buy and rental prices now. Not just one or the other. Now you can set specific costs for the playerSide as well!

**_fn_vehicleShopLBChange.sqf_**
-Side specific buy and rental prices now. Not just one or the other. Now you can set specific costs for the playerSide as well!

**_fn_vInteractionMenu.sqf_**
-Added a closeDialog to close the menu while impounding the vehicle. Shouldn't be a need for any of the others at this point...

**_fn_garageLBChange.sqf_**
-Side specific buy and rental prices now. Not just one or the other. Now you can set specific costs for the playerSide as well!

**_fn_sellGarage.sqf_**
-Removed "_unit" as it wasn't being used anywhere.
-Added a Bank sync when selling a vehicle
-You will get half of whatever you paid for the vehicle by default.

**_fn_unimpound.sqf_**
-Matched new formats
-Added a Bank sync when pulling out a vehicle

**_mission.sqm_**
-Added distance restriction to avoid exploiting by 2 players selling the same vehicle. You could potentially bypass the player near detection without this..

**_stringtable.xml_**
-Added "STR_NOTF_notAllowed" for a notification to non-civilians when trying to chop vehicles
-Reworded STR_NOTF_OwnImpounded
-Re-purposed the previously UNUSED "STR_NOTF_PlayerNear"