### PR TITLE
Increased Char Size

### DIFF
--- a/altislife.sql
+++ b/altislife.sql
@@ -95,7 +95,7 @@ CREATE TABLE IF NOT EXISTS `players` (
 CREATE TABLE IF NOT EXISTS `vehicles` (
   `id` int(12) NOT NULL AUTO_INCREMENT,
   `side` varchar(15) NOT NULL,
-  `classname` varchar(32) NOT NULL,
+  `classname` varchar(64) NOT NULL,
   `type` varchar(12) NOT NULL,
   `pid` varchar(32) NOT NULL,
   `alive` tinyint(1) NOT NULL DEFAULT '1',


### PR DESCRIPTION
Noticed some veh exceed this amount and do not get saved into the db. 

B_Heli_Transport_03_unarmed_green_F

For safe measure, changed to 64 (Apex may have longer classnames than 32)