### PR TITLE
#541 Fixes - Spawning in air

### DIFF
--- a/Altis_Life.Altis/core/fn_initCiv.sqf
+++ b/Altis_Life.Altis/core/fn_initCiv.sqf
@@ -14,7 +14,7 @@ civ_spawn_4 = nearestObjects[getMarkerPos  "civ_spawn_4", ["Land_i_Shop_01_V1_F"
 waitUntil {!(isNull (findDisplay 46))};
 if(life_is_alive && !life_is_arrested) then {
 	/* Spawn at our last position */
-	player setPosWorld life_civ_position;
+	player setVehiclePosition [life_civ_position, [], 0, "CAN_COLLIDE"];
 } else {
 	if(!life_is_alive && !life_is_arrested) then {
 		if(EQUAL(LIFE_SETTINGS(getNumber,"save_civilian_positionStrict"),1)) then {

--- a/Altis_Life.Altis/core/session/fn_updatePartial.sqf
+++ b/Altis_Life.Altis/core/session/fn_updatePartial.sqf
@@ -39,7 +39,7 @@ switch(_mode) do {
 
 	case 4: {
 		_packet set[2,life_is_alive];
-		_packet set[4,getPosWorld player];
+		_packet set[4,getPosATL player];
 	};
 
 	case 5: {

--- a/Altis_Life.Altis/core/session/fn_updateRequest.sqf
+++ b/Altis_Life.Altis/core/session/fn_updateRequest.sqf
@@ -10,7 +10,7 @@ private["_packet","_array","_flag","_alive","_position"];
 _packet = [getPlayerUID player,(profileName),playerSide,CASH,BANK];
 _array = [];
 _alive = alive player;
-_position = getPosWorld player;
+_position = getPosATL player;
 _flag = switch(playerSide) do {case west: {"cop"}; case civilian: {"civ"}; case independent: {"med"};};
 
 {

--- a/life_server/Functions/Systems/fn_clientDisconnect.sqf
+++ b/life_server/Functions/Systems/fn_clientDisconnect.sqf
@@ -17,7 +17,7 @@ _side = side _unit;
 
 //Save player info
 if(isNil "HC_UID" || {_uid != HC_UID}) then {
-	_position = getPosWorld _unit;
+	_position = getPosATL _unit;
 	if((getMarkerPos "respawn_civilian" distance _position) > 300) then {
 		//Call UpdateRequest as unit
 		[] remoteExecCall ["SOCK_fnc_updateRequest",_unit];


### PR DESCRIPTION
#541 This will set the players position on top of the nearest colliding (walkable) surface equal or below their elevation when they logged out (if their elevation is negative and they are on land, they spawn on the ground). I.e, if they logged out on a roof, they will spawn there. In the case they log on mid air (vehicle), they will spawn on the ground below it. If they were in the ocean (above or below), they will spawn on the surface. Had a fight with my laptop while setting up git again, ignore the spam of commits on the issue. Enjoy!