### PR TITLE
Fix the fixes

### DIFF
--- a/Altis_Life.Altis/core/cop/fn_restrain.sqf
+++ b/Altis_Life.Altis/core/cop/fn_restrain.sqf
@@ -77,6 +77,7 @@ while {player GVAR  "restrained"} do {
 		{
 			if (_vehicle turretUnit [_x select 0] == player) then {
 				player action["eject",vehicle player];
+				sleep 1;
 				player moveInCargo _vehicle;
 			};
 		}forEach _turrets;

--- a/Altis_Life.Altis/core/functions/fn_actionKeyHandler.sqf
+++ b/Altis_Life.Altis/core/functions/fn_actionKeyHandler.sqf
@@ -26,14 +26,14 @@ if(EQUAL(LIFE_SETTINGS(getNumber,"global_ATM"),1)) then{
 
 if(isNull _curObject) exitWith {
 	if(_isWater) then {
-		_fish = (nearestObjects[ASLtoATL (getPosASL player),(LIFE_SETTINGS(getArray,"animaltypes_fish")),3]) select 0;
+		_fish = (nearestObjects[player,(LIFE_SETTINGS(getArray,"animaltypes_fish")),3]) select 0;
 		if(!isNil "_fish") then {
 			if (!alive _fish) then {
 				[_fish] call life_fnc_catchFish;
 			};
 		};
 	} else {
-		_animal = (nearestObjects[ASLtoATL (getPosASL player),(LIFE_SETTINGS(getArray,"animaltypes_hunting")),3]) select 0;
+		_animal = (nearestObjects[player,(LIFE_SETTINGS(getArray,"animaltypes_hunting")),3]) select 0;
 		if (!isNil "_animal") then {
 			if (!alive _animal) then {
 				[_animal] call life_fnc_gutAnimal;


### PR DESCRIPTION
Without the sleep in restrain, the player will not be moved back into the vehicle (happens too quickly).

Using ASLtoATL (getPosASL player) is the equivalent of using getPosATL, and even then using ATL in nearestObjects in this scenario is wrong. Using just the object player is absolutely fine.